### PR TITLE
Placegoose enhancements

### DIFF
--- a/examples/placegoose/README.md
+++ b/examples/placegoose/README.md
@@ -1,5 +1,21 @@
 # placegoose
 
+## Take a gander!
+```typescript
+// Run this code in a console, or from any app:
+fetch("https://placegoose.mies.workers.dev/geese/1")
+    .then((response) => response.json())
+    .then((json) => console.log(json));
+```
+
+## What's it good for?
+Placegoose is a free online REST API for moments when you **just need some honkin data!** More than that, it's a learning resource for building blazing-fast REST APIs with the [HO(N)C stack.](https://honc.dev/#overview) You're welcome to use it as a reference, or clone the repo and modify the schema to fit your use-case.
+
+## How does the API work?
+Placegoose comes with 3 goose-themed resources, supporting _up to_ all 5 common HTTP verbs. We don't actually make updates to the DB in response to write requests, but we do validate payloads and verify the target exists. If something's not right, we'll return an error with a helpful message.
+
+To learn more about making requests, or what different errors mean, [check out our guide!](https://placegoose.mies.workers.dev/#guide)
+
 ## Deployment
 To deploy the app, you'll need to provision and configure a production D1 instance.
 ```sh

--- a/examples/placegoose/_scripts/seed/index.ts
+++ b/examples/placegoose/_scripts/seed/index.ts
@@ -11,7 +11,7 @@ import {
 } from "drizzle-orm/sqlite-proxy";
 
 import * as schema from "../../src/db/schema";
-import { getLocalD1DBPath } from "../../src/db/utils";
+import { getLocalSQLiteDBPath } from "../../src/db/utils";
 import * as seedData from "./data";
 import { config } from "dotenv";
 import { SQLiteColumn, SQLiteTableWithColumns } from "drizzle-orm/sqlite-core";

--- a/examples/placegoose/_scripts/seed/index.ts
+++ b/examples/placegoose/_scripts/seed/index.ts
@@ -1,30 +1,28 @@
-import { createClient } from "@libsql/client";
+import { config } from "dotenv";
 import {
   drizzle as drizzleLibsql,
   type LibSQLDatabase,
 } from "drizzle-orm/libsql";
+import type { SQLiteTable } from "drizzle-orm/sqlite-core";
 import {
   type AsyncBatchRemoteCallback,
   type AsyncRemoteCallback,
   drizzle as drizzleSQLiteProxy,
   type SqliteRemoteDatabase,
 } from "drizzle-orm/sqlite-proxy";
+import { createClient } from "@libsql/client";
 
 import * as schema from "../../src/db/schema";
-import { getLocalSQLiteDBPath } from "../../src/db/utils";
 import * as seedData from "./data";
-import { config } from "dotenv";
-import { SQLiteColumn, SQLiteTableWithColumns } from "drizzle-orm/sqlite-core";
-import { ColumnBaseConfig } from "drizzle-orm/column";
-import { ColumnDataType } from "drizzle-orm/column-builder";
+import { getLocalSQLiteDBPath } from "../../src/db/utils";
 
 // biome-ignore lint/suspicious/noExplicitAny: Centralize usage of `any` type (we use it in db results that are not worth typing)
 type Any = any;
 
 // Ensure database clients expect snake_case column names
 const DB_CONFIG = {
-  casing: "snake_case" as const,
-};
+  casing: "snake_case",
+} as const;
 
 seedDatabase();
 
@@ -35,17 +33,9 @@ seedDatabase();
  */
 async function seedDatabase() {
   try {
-    let db:
-      | LibSQLDatabase<Record<string, never>>
-      | SqliteRemoteDatabase<Record<string, never>>;
-
-    if (process.env.ENVIRONMENT === "production") {
-      console.warn("Using production D1 database");
-      db = await seedProductionDatabase();
-    } else {
-      console.log("Using local D1 database");
-      db = await seedLocalDatabase();
-    }
+    const db = process.env.ENVIRONMENT === "production"
+      ? await getProductionDatabase()
+      : await getLocalDatabase();
 
     console.log("Seeding database...");
 
@@ -56,7 +46,7 @@ async function seedDatabase() {
     // Helper function to insert data in chunks
     // We do this because Cloudflare D1 has a restriction on the number of SQL variables you can use in a single query,
     // and we bumped into that for production seeding
-    const insertInChunks = async <T>(table: Any, data: T[]) => {
+    const insertInChunks = async <T extends SQLiteTable>(table: T, data: T["$inferInsert"][]) => {
       const chunks = chunkArray(data, batchSize);
       for (const chunk of chunks) {
         await db.insert(table).values(chunk);
@@ -82,10 +72,11 @@ async function seedDatabase() {
  * @returns {Promise<LibSQLDatabase>} Drizzle ORM instance connected to local database
  * @throws {Error} If local database path cannot be resolved
  */
-async function seedLocalDatabase(): Promise<
+async function getLocalDatabase(): Promise<
   LibSQLDatabase<Record<string, never>>
 > {
-  const dbPath = getLocalD1DBPath();
+  console.log("Using local SQLite database");
+  const dbPath = getLocalSQLiteDBPath();
 
   if (!dbPath) {
     console.error("Database seed failed: local DB could not be resolved");
@@ -105,9 +96,10 @@ async function seedLocalDatabase(): Promise<
  * @returns {Promise<SqliteRemoteDatabase>} Drizzle ORM instance connected to production database
  * @throws {Error} If required environment variables are not set
  */
-async function seedProductionDatabase(): Promise<
+async function getProductionDatabase(): Promise<
   SqliteRemoteDatabase<Record<string, never>>
 > {
+  console.warn("Using production D1 database");
   config({ path: ".prod.vars" });
 
   const apiToken = process.env.CLOUDFLARE_D1_TOKEN;

--- a/examples/placegoose/drizzle.config.ts
+++ b/examples/placegoose/drizzle.config.ts
@@ -2,7 +2,7 @@ import "dotenv/config";
 import { config } from "dotenv";
 import { type Config, defineConfig } from "drizzle-kit";
 
-import { getLocalD1DBPath } from "./src/db/utils";
+import { getLocalSQLiteDBPath } from "./src/db/utils";
 
 let drizzleConfig: Config;
 
@@ -12,7 +12,6 @@ let drizzleConfig: Config;
  * env from accidentally being applied to another
  */
 
-// todo: will this break too?
 if (process.env.ENVIRONMENT === "production") {
   config({ path: "./.prod.vars" });
 
@@ -41,7 +40,7 @@ if (process.env.ENVIRONMENT === "production") {
 } else {
   config({ path: "./.dev.vars" });
 
-  const localDbPath = getLocalD1DBPath();
+  const localDbPath = getLocalSQLiteDBPath();
 
   if (!localDbPath) {
     console.error("Configuration Failed: Missing Local DB");

--- a/examples/placegoose/package.json
+++ b/examples/placegoose/package.json
@@ -20,12 +20,12 @@
     "@hono-rate-limiter/cloudflare": "^0.2.1",
     "dotenv": "^16.4.5",
     "drizzle-orm": "^0.36.4",
+    "drizzle-zod": "^0.5.1",
     "hono": "^4.6.11",
     "hono-rate-limiter": "^0.4.0",
     "marked": "^15.0.2",
     "marked-highlight": "^2.2.1",
-    "prismjs": "^1.29.0",
-    "zod": "^3.23.8"
+    "prismjs": "^1.29.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/examples/placegoose/package.json
+++ b/examples/placegoose/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "@cloudflare/workers-types": "^4.20241022.0",
-    "@fiberplane/hono-otel": "^0.3.1",
+    "@fiberplane/hono-otel": "^0.5.1",
     "@fiberplane/studio": "^0.11.0",
     "@libsql/client": "^0.14.0",
     "@types/prismjs": "^1.26.5",

--- a/examples/placegoose/src/components/Layout.tsx
+++ b/examples/placegoose/src/components/Layout.tsx
@@ -12,6 +12,7 @@ export default function Layout({ children }: { children?: unknown }) {
       <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="color-scheme" content="dark light" />
         <meta name="description" content={meta.description} />
         <meta name="og:title" content={meta.title} />
         <meta name="og:description" content={meta.description} />

--- a/examples/placegoose/src/controllers/index.ts
+++ b/examples/placegoose/src/controllers/index.ts
@@ -63,7 +63,6 @@ async function getRowByIdExists<T extends ColumnWithId>(
   table: SQLiteTableWithIdColumn<T>,
   id: number,
 ) {
-
   const { rowExists } = await db.get<{ rowExists: boolean }>(
     sql`select exists (select 1 from ${table} where ${table.id} = ${id}) as rowExists`,
   );

--- a/examples/placegoose/src/controllers/index.ts
+++ b/examples/placegoose/src/controllers/index.ts
@@ -69,9 +69,9 @@ type DrizzleClient = DrizzleD1Database<typeof schema> & {
   $client: D1Database;
 };
 
-/** 
+/**
  * This is a fragile solution, but Drizzle typing is somewhat
- * challenging as soon as 
+ * challenging as soon as generics come into the picture
  */
 type PlacegooseTable =
   | typeof schema.gaggles

--- a/examples/placegoose/src/controllers/index.ts
+++ b/examples/placegoose/src/controllers/index.ts
@@ -63,8 +63,9 @@ async function getRowByIdExists<T extends ColumnWithId>(
   table: SQLiteTableWithIdColumn<T>,
   id: number,
 ) {
-  const rowExists = db.run(
-    sql`select exists (select 1 from ${table} where ${table.id} = ${id})`,
+
+  const { rowExists } = await db.get<{ rowExists: boolean }>(
+    sql`select exists (select 1 from ${table} where ${table.id} = ${id}) as rowExists`,
   );
 
   return !!rowExists;

--- a/examples/placegoose/src/db/index.ts
+++ b/examples/placegoose/src/db/index.ts
@@ -1,6 +1,7 @@
 import { drizzle } from "drizzle-orm/d1";
 import type * as schema from "./schema";
 
+/** @returns Drizzle D1 Driver with default configurations */
 export function getDb(client: D1Database) {
   // Ensure client expects snake_case column names
   return drizzle<typeof schema>(client, { casing: "snake_case" });

--- a/examples/placegoose/src/db/utils.ts
+++ b/examples/placegoose/src/db/utils.ts
@@ -2,9 +2,11 @@ import fs from "node:fs";
 import path from "node:path";
 
 /**
+ * Used when connecting to local SQLite db during seeding and migrations,
+ * or when making queries against the db.
  * @returns Path to most recent .sqlite file in the .wrangler directory
  */
-export function getLocalD1DBPath() {
+export function getLocalSQLiteDBPath() {
   try {
     // .wrangler dir and process execution are assumed to be colocated
     const basePath = path.resolve(".wrangler");

--- a/examples/placegoose/src/db/validation.ts
+++ b/examples/placegoose/src/db/validation.ts
@@ -1,0 +1,14 @@
+import { createInsertSchema, createSelectSchema } from "drizzle-zod";
+import * as schema from "./schema";
+
+export const ZGaggleInsert = createInsertSchema(schema.gaggles);
+
+export const ZGaggleSelect = createSelectSchema(schema.gaggles);
+
+export const ZGooseInsert = createInsertSchema(schema.geese);
+
+export const ZGooseSelect = createSelectSchema(schema.geese);
+
+export const ZHonkInsert = createInsertSchema(schema.honks);
+
+export const ZHonkSelect = createSelectSchema(schema.honks);

--- a/examples/placegoose/src/db/validation.ts
+++ b/examples/placegoose/src/db/validation.ts
@@ -1,6 +1,10 @@
 import { createInsertSchema, createSelectSchema } from "drizzle-zod";
 import * as schema from "./schema";
 
+// This level of separation is somewhat forced at this scale.
+// The decision was made for clarity, and to exclude these
+// from the "schema" file export
+
 export const ZGaggleInsert = createInsertSchema(schema.gaggles);
 
 export const ZGaggleSelect = createSelectSchema(schema.gaggles);

--- a/examples/placegoose/src/db/validation.ts
+++ b/examples/placegoose/src/db/validation.ts
@@ -5,11 +5,17 @@ import * as schema from "./schema";
 // The decision was made for clarity, and to exclude these
 // from the "schema" file export
 
-export const ZGaggleInsert = createInsertSchema(schema.gaggles);
+export const ZGaggleInsert = createInsertSchema(schema.gaggles, {
+    // Enhance (or override) property schemas
+    name: (schema) => schema.name.min(1),
+    territory: (schema) => schema.territory.min(1),
+});
 
 export const ZGaggleSelect = createSelectSchema(schema.gaggles);
 
-export const ZGooseInsert = createInsertSchema(schema.geese);
+export const ZGooseInsert = createInsertSchema(schema.geese, {
+    name: (schema) => schema.name.min(1),
+});
 
 export const ZGooseSelect = createSelectSchema(schema.geese);
 

--- a/examples/placegoose/src/dtos/index.ts
+++ b/examples/placegoose/src/dtos/index.ts
@@ -1,5 +1,9 @@
 import { ZGaggleInsert, ZHonkInsert } from "../db/validation";
 
+// DTOs (Data Transfer Objects) form a validation/construction
+// layer, commonly implemented with Classes or constructor functions,
+// that regulates the transferring of data between other layers.
+
 // Define runtime validation for request data. This need not be
 // derived from the Drizzle schema, but it is here for convenience.
 

--- a/examples/placegoose/src/dtos/index.ts
+++ b/examples/placegoose/src/dtos/index.ts
@@ -1,0 +1,13 @@
+import { ZGaggleInsert, ZHonkInsert } from "../db/validation";
+
+export const ZGaggleInsertPayload = ZGaggleInsert.omit({
+  id: true,
+});
+
+export const ZHonkInsertPayload = ZHonkInsert.omit({
+  id: true,
+});
+
+export const ZHonkUpdatePayload = ZHonkInsertPayload.omit({
+  gooseId: true,
+});

--- a/examples/placegoose/src/dtos/index.ts
+++ b/examples/placegoose/src/dtos/index.ts
@@ -1,5 +1,8 @@
 import { ZGaggleInsert, ZHonkInsert } from "../db/validation";
 
+// Define runtime validation for request data. This need not be
+// derived from the Drizzle schema, but it is here for convenience.
+
 export const ZGaggleInsertPayload = ZGaggleInsert.omit({
   id: true,
 });

--- a/examples/placegoose/src/lib/markdown.ts
+++ b/examples/placegoose/src/lib/markdown.ts
@@ -2,7 +2,14 @@ import { Marked } from "marked";
 import { markedHighlight } from "marked-highlight";
 import Prism from "prismjs";
 
-// https://www.npmjs.com/package/marked-highlight
+/**
+ * Markdown is a simple way to serve lightly-formatted text content,
+ * especially for docs. Marked is a popular and highly-extensible
+ * compiler. **It does not sanitize html!**
+ * A plugin is required for syntax highlighting
+ * @see https://www.npmjs.com/package/marked-highlight
+ */
+
 const marked = new Marked(
   markedHighlight({
     highlight: (code) => {
@@ -12,10 +19,17 @@ const marked = new Marked(
   }),
 );
 
+/**
+ * Marked doesn't recognize any tokens as id attributes. To
+ * allow links to headings, override the default header rendering.
+ * The #{id-value} pattern is a markdown standard.
+ */
+
 marked.use({
   renderer: {
     heading({ tokens, depth }) {
       const text = this.parser.parseInline(tokens);
+      // Match headings ending with an "#{id-value}"
       const idMatch = text.match(/\{#([\w-]+)\}$/);
 
       const idAttribute = idMatch ? `id="${idMatch[1]}"` : "";
@@ -27,6 +41,7 @@ marked.use({
   },
 });
 
+/** @returns Unsanitized html compiled from the markdown source */
 export function mdToHtml(markdown: string) {
   return marked.parse(markdown);
 }

--- a/examples/placegoose/src/lib/utils.ts
+++ b/examples/placegoose/src/lib/utils.ts
@@ -1,7 +1,9 @@
 function getNumberBetween(min: number, max: number) {
+  // + 1 for inclusivity
   return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 
+/** @returns A number between 50 and 100, using Math.random */
 export function generateId() {
   return getNumberBetween(50, 100);
 }

--- a/examples/placegoose/src/lib/validation.ts
+++ b/examples/placegoose/src/lib/validation.ts
@@ -6,7 +6,7 @@ import { HTTPException } from "hono/http-exception";
  * for processing payload errors
  */
 export function makeBodyValidator<T extends Zod.AnyZodObject>(schema: T) {
-  return function bodyValidator(body: unknown): T["_output"] {
+  return (body: unknown): T["_output"] => {
     const result = schema.safeParse(body);
 
     if (result.success) {

--- a/examples/placegoose/src/lib/validation.ts
+++ b/examples/placegoose/src/lib/validation.ts
@@ -11,9 +11,13 @@ export function makeBodyValidator<T extends Record<string, unknown>>(
   return (body: unknown) => {
     try {
       // Return value must be consistent with shape of "body"
+      // Available through Context.req.valid
       return parse(body);
     } catch (error) {
       console.error(error);
+
+      // todo
+
       throw new HTTPException(400, {
         message: "Invalid Payload",
         cause: error,
@@ -40,6 +44,7 @@ export function validateId(value: string | string[]) {
 /**
  * Validation fn for hono param validator. Throws if id is missing
  * or invalid
+ * @returns Any validated params, available through Context.req.valid
  */
 export function validateIdParam(params: Record<string, string>, c: Context) {
   const idParam = params.id;

--- a/examples/placegoose/src/lib/validation.ts
+++ b/examples/placegoose/src/lib/validation.ts
@@ -5,24 +5,20 @@ import { HTTPException } from "hono/http-exception";
  * @returns Validation fn for Hono body validator, responsible
  * for processing payload errors
  */
-export function makeBodyValidator<T extends Record<string, unknown>>(
-  parse: (data: unknown) => T,
-) {
-  return (body: unknown) => {
-    try {
+export function makeBodyValidator<T extends Zod.AnyZodObject>(schema: T) {
+  return function bodyValidator(body: unknown): T["_output"] {
+    const result = schema.safeParse(body);
+
+    if (result.success) {
       // Return value must be consistent with shape of "body"
       // Available through Context.req.valid
-      return parse(body);
-    } catch (error) {
-      console.error(error);
-
-      // todo
-
-      throw new HTTPException(400, {
-        message: "Invalid Payload",
-        cause: error,
-      });
+      return result.data;
     }
+
+    throw new HTTPException(400, {
+      message: "Invalid Payload",
+      cause: result.error,
+    });
   };
 }
 
@@ -57,4 +53,37 @@ export function validateIdParam(params: Record<string, string>, c: Context) {
 
   // Return value must be consistent with shape of "params"
   return { id: validateId(idParam) };
+}
+
+/**
+ * Checks error name as a simple alternative to an instanceof,
+ * as Zod is not a direct project dependency
+ */
+export function isZodError(error: Error): error is Zod.ZodError {
+  return error.name === "ZodError";
+}
+
+/**
+ * @returns Record of field paths with arrays of field-specific error messages
+ */
+export function formatZodError(zodError: Zod.ZodError) {
+  return zodError.issues.reduce(
+    (result: Record<string, string[]>, { path, message }) => {
+      const dotPath = path.join(".");
+
+      /**
+       * This implementation will break if any validation targets have
+       * nested data. In that case, consider using Lodash.get, or alternative
+       * @see https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore?tab=readme-ov-file#_get
+       */
+      if (result[dotPath]) {
+        result[dotPath].push(message);
+      } else {
+        result[dotPath] = [message];
+      }
+
+      return result;
+    },
+    {},
+  );
 }

--- a/examples/placegoose/src/pages/index.md
+++ b/examples/placegoose/src/pages/index.md
@@ -220,6 +220,8 @@ Whens something goes wrong, we'll try and share a helpful message! If you're run
 ```
 type ErrorData = {
     message: string;
+    /** Only included for validation errors */
+    issues?: Record<string, string[]>;
 }
 ```
 

--- a/examples/placegoose/src/pages/index.md
+++ b/examples/placegoose/src/pages/index.md
@@ -7,7 +7,7 @@ fetch("https://placegoose.mies.workers.dev/geese/1")
 ```
 
 ## What's it good for?
-Placegoose is a free online REST API for moments when you **just need some honkin data**! More than that, it's a learning resource for building blazing-fast REST APIs with the [HO(N)C stack.](https://honc.dev/#overview) You're welcome to use it as a reference, or clone the repo and modify the schema to fit your use-case.
+Placegoose is a free online REST API for moments when you **just need some honkin data!** More than that, it's a learning resource for building blazing-fast REST APIs with the [HO(N)C stack.](https://honc.dev/#overview) You're welcome to use it as a reference, or clone the repo and modify the schema to fit your use-case.
 
 ## How does the API work?
 Placegoose comes with 3 goose-themed resources, supporting _up to_ all 5 common HTTP verbs. We don't actually make updates to the DB in response to write requests, but we do validate payloads and verify the target exists. If something's not right, we'll return an error with a helpful message.
@@ -24,7 +24,7 @@ To learn more about making requests, or what different errors mean, [check out o
 ## Flying solo
 You might want to build your own (mock?) data service, or may just be curious about the stack. This project was built using [Hono](https://hono.dev/) and [Drizzle ORM](https://orm.drizzle.team/) to highlight core features and implementation patterns. For more examples, or to get going with a template, [check out our repo.](https://github.com/fiberplane/create-honc-app)
 
-Take a deep dive into the development process and key features of the stack in our blog post. You'll need a basic understanding of TypeScript REST APIs and Cloudflare, but we tried to cover everything you'll need to get started!
+Take a deep dive into the development process and key features of the stack in [our blog series.](https://fiberplane.com/blog/) You'll need a basic understanding of TypeScript REST APIs and Cloudflare, but we tried to cover everything you'll need to get started!
 
 ## Making requests {#guide}
 - **No updates are made to the DB.** Responses to write operations are simulated by merging the validated request payload with the stored data.

--- a/examples/placegoose/src/routes/gaggles.ts
+++ b/examples/placegoose/src/routes/gaggles.ts
@@ -24,7 +24,7 @@ gagglesApp.get("/", async (c) => {
 // Create a new Gaggle
 gagglesApp.post(
   "/",
-  validator("json", makeBodyValidator(ZGaggleInsertPayload.parse)),
+  validator("json", makeBodyValidator(ZGaggleInsertPayload)),
   async (c) => {
     const gaggleData = c.req.valid("json");
 
@@ -80,7 +80,7 @@ gagglesApp.get("/:id/geese", validator("param", validateIdParam), async (c) => {
 gagglesApp.put(
   "/:id",
   validator("param", validateIdParam),
-  validator("json", makeBodyValidator(ZGaggleInsertPayload.parse)),
+  validator("json", makeBodyValidator(ZGaggleInsertPayload)),
   async (c) => {
     const { id } = c.req.valid("param");
     const gaggleData = c.req.valid("json");

--- a/examples/placegoose/src/routes/gaggles.ts
+++ b/examples/placegoose/src/routes/gaggles.ts
@@ -32,7 +32,7 @@ gagglesApp.post(
       id: generateId(),
       // Default for optional property
       territory: null,
-      ...gaggleData
+      ...gaggleData,
     };
 
     return c.json(newGaggle, 201);

--- a/examples/placegoose/src/routes/honks.ts
+++ b/examples/placegoose/src/routes/honks.ts
@@ -61,7 +61,7 @@ honksApp.get(
 // Create a new Honk
 honksApp.post(
   "/",
-  validator("json", makeBodyValidator(ZHonkInsertPayload.parse)),
+  validator("json", makeBodyValidator(ZHonkInsertPayload)),
   async (c) => {
     const honkData = c.req.valid("json");
     const gooseId = honkData.gooseId;
@@ -104,7 +104,7 @@ honksApp.get("/:id", validator("param", validateIdParam), async (c) => {
 honksApp.patch(
   "/:id",
   validator("param", validateIdParam),
-  validator("json", makeBodyValidator(ZHonkUpdatePayload.parse)),
+  validator("json", makeBodyValidator(ZHonkUpdatePayload)),
   async (c) => {
     const { id } = c.req.valid("param");
     const { decibels } = c.req.valid("json");
@@ -143,7 +143,7 @@ honksApp.patch(
 honksApp.put(
   "/:id",
   validator("param", validateIdParam),
-  validator("json", makeBodyValidator(ZHonkUpdatePayload.parse)),
+  validator("json", makeBodyValidator(ZHonkUpdatePayload)),
   async (c) => {
     const { id } = c.req.valid("param");
     const { decibels } = c.req.valid("json");

--- a/examples/placegoose/src/routes/honks.ts
+++ b/examples/placegoose/src/routes/honks.ts
@@ -117,7 +117,7 @@ honksApp.patch(
     const includesGooseId = Boolean((await c.req.json()).gooseId);
     if (includesGooseId) {
       throw new HTTPException(403, {
-        message: "Honks are read-only properties",
+        message: "Honk.gooseId is a read-only property",
       });
     }
 
@@ -151,7 +151,7 @@ honksApp.put(
     const includesGooseId = Boolean((await c.req.json()).gooseId);
     if (includesGooseId) {
       throw new HTTPException(403, {
-        message: "Honks are read-only properties",
+        message: "Honk.gooseId is a read-only property",
       });
     }
 

--- a/examples/placegoose/src/routes/honks.ts
+++ b/examples/placegoose/src/routes/honks.ts
@@ -26,7 +26,7 @@ honksApp.get(
   "/",
   validator("query", (query) => {
     const gooseIdQuery = query.gooseId;
-
+    // gooseId filter is optional
     return {
       gooseId: gooseIdQuery ? validateId(gooseIdQuery) : undefined,
     };
@@ -109,6 +109,11 @@ honksApp.patch(
     const { id } = c.req.valid("param");
     const { decibels } = c.req.valid("json");
 
+    /**
+     * Zod strips unrecognized keys. To inform users that
+     * an attempted gooseId update was invalid, we check the
+     * unvalidated body for the ineligible key
+     */
     const includesGooseId = Boolean((await c.req.json()).gooseId);
     if (includesGooseId) {
       throw new HTTPException(403, {

--- a/examples/placegoose/src/routes/honks.ts
+++ b/examples/placegoose/src/routes/honks.ts
@@ -2,7 +2,6 @@ import { eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { validator } from "hono/validator";
-import { z } from "zod";
 
 import {
   getGooseByIdExists,
@@ -11,6 +10,7 @@ import {
 } from "../controllers";
 import { getDb } from "../db";
 import * as schema from "../db/schema";
+import { ZHonkInsertPayload, ZHonkUpdatePayload } from "../dtos";
 import { generateId } from "../lib/utils";
 import {
   makeBodyValidator,
@@ -18,13 +18,6 @@ import {
   validateIdParam,
 } from "../lib/validation";
 import type { AppType } from "../types";
-
-const ZHonkInsert = z.object({
-  gooseId: z.number(),
-  decibels: z.number(),
-});
-
-const ZHonkUpdate = ZHonkInsert.omit({ gooseId: true });
 
 const honksApp = new Hono<AppType>();
 
@@ -68,7 +61,7 @@ honksApp.get(
 // Create a new Honk
 honksApp.post(
   "/",
-  validator("json", makeBodyValidator(ZHonkInsert.parse)),
+  validator("json", makeBodyValidator(ZHonkInsertPayload.parse)),
   async (c) => {
     const honkData = c.req.valid("json");
     const gooseId = honkData.gooseId;
@@ -111,7 +104,7 @@ honksApp.get("/:id", validator("param", validateIdParam), async (c) => {
 honksApp.patch(
   "/:id",
   validator("param", validateIdParam),
-  validator("json", makeBodyValidator(ZHonkUpdate.parse)),
+  validator("json", makeBodyValidator(ZHonkUpdatePayload.parse)),
   async (c) => {
     const { id } = c.req.valid("param");
     const { decibels } = c.req.valid("json");
@@ -145,7 +138,7 @@ honksApp.patch(
 honksApp.put(
   "/:id",
   validator("param", validateIdParam),
-  validator("json", makeBodyValidator(ZHonkUpdate.parse)),
+  validator("json", makeBodyValidator(ZHonkUpdatePayload.parse)),
   async (c) => {
     const { id } = c.req.valid("param");
     const { decibels } = c.req.valid("json");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,7 +93,7 @@ importers:
         version: 4.20241106.0
       '@fiberplane/hono-otel':
         specifier: latest
-        version: 0.3.1
+        version: 0.5.0
       '@types/node':
         specifier: ^22.2.0
         version: 22.9.0
@@ -194,7 +194,7 @@ importers:
         version: 4.20241106.0
       '@fiberplane/hono-otel':
         specifier: latest
-        version: 0.3.1
+        version: 0.5.0
       drizzle-kit:
         specifier: ^0.28.1
         version: 0.28.1
@@ -231,7 +231,7 @@ importers:
         version: 4.20241106.0
       '@fiberplane/hono-otel':
         specifier: latest
-        version: 0.3.1
+        version: 0.5.0
       drizzle-kit:
         specifier: ^0.28.1
         version: 0.28.1
@@ -259,6 +259,9 @@ importers:
       drizzle-orm:
         specifier: ^0.36.4
         version: 0.36.4(@cloudflare/workers-types@4.20241106.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@neondatabase/serverless@0.10.1)(@opentelemetry/api@1.9.0)(@types/pg@8.11.10)(pg@8.13.1)(react@18.3.1)
+      drizzle-zod:
+        specifier: ^0.5.1
+        version: 0.5.1(drizzle-orm@0.36.4(@cloudflare/workers-types@4.20241106.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@neondatabase/serverless@0.10.1)(@opentelemetry/api@1.9.0)(@types/pg@8.11.10)(pg@8.13.1)(react@18.3.1))(zod@3.23.8)
       hono:
         specifier: ^4.6.11
         version: 4.6.11
@@ -274,9 +277,6 @@ importers:
       prismjs:
         specifier: ^1.29.0
         version: 1.29.0
-      zod:
-        specifier: ^3.23.8
-        version: 3.23.8
     devDependencies:
       '@biomejs/biome':
         specifier: ^1.9.4
@@ -289,7 +289,7 @@ importers:
         version: 0.3.1
       '@fiberplane/studio':
         specifier: ^0.11.0
-        version: 0.11.0(@cloudflare/workers-types@4.20241106.0)(@neondatabase/serverless@0.10.1)(@opentelemetry/api@1.9.0)(@types/pg@8.11.10)(encoding@0.1.13)(pg@8.13.1)(react@18.3.1)(sswr@2.1.0(svelte@5.1.9))(svelte@5.1.9)
+        version: 0.11.0(@cloudflare/workers-types@4.20241106.0)(@neondatabase/serverless@0.10.1)(@opentelemetry/api@1.9.0)(@types/pg@8.11.10)(encoding@0.1.13)(pg@8.13.1)(react@18.3.1)(sswr@2.1.0(svelte@5.1.9))(svelte@5.1.9)(vue@3.5.12(typescript@5.6.2))
       '@libsql/client':
         specifier: ^0.14.0
         version: 0.14.0
@@ -363,7 +363,7 @@ importers:
         version: 4.20241106.0
       '@fiberplane/hono-otel':
         specifier: latest
-        version: 0.3.1
+        version: 0.5.0
       drizzle-kit:
         specifier: ^0.28.1
         version: 0.28.1
@@ -1248,6 +1248,9 @@ packages:
 
   '@fiberplane/hono-otel@0.3.1':
     resolution: {integrity: sha512-E5Gpg06jMngM3gyIjhy4lFuGAv8Qpx0gnglmSgUeuEAkrpAAPy4tHpoFZsFc+gLgoM5+KytoI3MFowgheHjacg==}
+
+  '@fiberplane/hono-otel@0.5.0':
+    resolution: {integrity: sha512-ji54FWoRmhJL1V1YqgwetUKewFzQ/wEV5GWIYWIkMGN3BHg+h0QhtLHITUNcVqMyLxjf5W2I1qo3FcM0EOxayQ==}
 
   '@fiberplane/source-analysis@0.1.0':
     resolution: {integrity: sha512-2XI1ZmC0lkG78MMSNHzGQPaP4cFg658egdSU6bjU+FsAzGx0XJgQ7nInhYL7A6qDcTNCvSllYttOuyn6Mm4/Xg==}
@@ -3763,6 +3766,16 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
+  '@ai-sdk/vue@0.0.59(vue@3.5.12(typescript@5.6.2))(zod@3.23.8)':
+    dependencies:
+      '@ai-sdk/provider-utils': 1.0.22(zod@3.23.8)
+      '@ai-sdk/ui-utils': 0.0.50(zod@3.23.8)
+      swrv: 1.0.4(vue@3.5.12(typescript@5.6.2))
+    optionalDependencies:
+      vue: 3.5.12(typescript@5.6.2)
+    transitivePeerDependencies:
+      - zod
+
   '@ampproject/remapping@2.3.0':
     dependencies:
       '@jridgewell/gen-mapping': 0.3.5
@@ -4244,6 +4257,17 @@ snapshots:
       '@types/shimmer': 1.2.0
       shimmer: 1.2.1
 
+  '@fiberplane/hono-otel@0.5.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/exporter-trace-otlp-http': 0.52.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-trace-otlp-proto': 0.52.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.27.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 1.27.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.27.0
+      '@types/shimmer': 1.2.0
+      shimmer: 1.2.1
+
   '@fiberplane/source-analysis@0.1.0':
     dependencies:
       chokidar: 3.6.0
@@ -4254,7 +4278,7 @@ snapshots:
       type-fest: 4.28.1
       typescript: 5.6.2
 
-  '@fiberplane/studio@0.11.0(@cloudflare/workers-types@4.20241106.0)(@neondatabase/serverless@0.10.1)(@opentelemetry/api@1.9.0)(@types/pg@8.11.10)(encoding@0.1.13)(pg@8.13.1)(react@18.3.1)(sswr@2.1.0(svelte@5.1.9))(svelte@5.1.9)':
+  '@fiberplane/studio@0.11.0(@cloudflare/workers-types@4.20241106.0)(@neondatabase/serverless@0.10.1)(@opentelemetry/api@1.9.0)(@types/pg@8.11.10)(encoding@0.1.13)(pg@8.13.1)(react@18.3.1)(sswr@2.1.0(svelte@5.1.9))(svelte@5.1.9)(vue@3.5.12(typescript@5.6.2))':
     dependencies:
       '@ai-sdk/anthropic': 0.0.51(zod@3.23.8)
       '@ai-sdk/mistral': 0.0.42(zod@3.23.8)
@@ -4267,7 +4291,7 @@ snapshots:
       '@iarna/toml': 2.2.5
       '@langchain/core': 0.2.36(openai@4.71.0(encoding@0.1.13)(zod@3.23.8))
       '@libsql/client': 0.6.2
-      ai: 3.4.33(openai@4.71.0(encoding@0.1.13)(zod@3.23.8))(react@18.3.1)(sswr@2.1.0(svelte@5.1.9))(svelte@5.1.9)(vue@3.5.12(typescript@5.5.4))(zod@3.23.8)
+      ai: 3.4.33(openai@4.71.0(encoding@0.1.13)(zod@3.23.8))(react@18.3.1)(sswr@2.1.0(svelte@5.1.9))(svelte@5.1.9)(vue@3.5.12(typescript@5.6.2))(zod@3.23.8)
       chalk: 5.3.0
       consola: 3.2.3
       dotenv: 16.4.5
@@ -4989,6 +5013,12 @@ snapshots:
       '@vue/shared': 3.5.12
       vue: 3.5.12(typescript@5.5.4)
 
+  '@vue/server-renderer@3.5.12(vue@3.5.12(typescript@5.6.2))':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.12
+      '@vue/shared': 3.5.12
+      vue: 3.5.12(typescript@5.6.2)
+
   '@vue/shared@3.5.12': {}
 
   abort-controller@3.0.0:
@@ -5018,6 +5048,31 @@ snapshots:
       '@ai-sdk/svelte': 0.0.57(svelte@5.1.9)(zod@3.23.8)
       '@ai-sdk/ui-utils': 0.0.50(zod@3.23.8)
       '@ai-sdk/vue': 0.0.59(vue@3.5.12(typescript@5.5.4))(zod@3.23.8)
+      '@opentelemetry/api': 1.9.0
+      eventsource-parser: 1.1.2
+      json-schema: 0.4.0
+      jsondiffpatch: 0.6.0
+      secure-json-parse: 2.7.0
+      zod-to-json-schema: 3.23.5(zod@3.23.8)
+    optionalDependencies:
+      openai: 4.71.0(encoding@0.1.13)(zod@3.23.8)
+      react: 18.3.1
+      sswr: 2.1.0(svelte@5.1.9)
+      svelte: 5.1.9
+      zod: 3.23.8
+    transitivePeerDependencies:
+      - solid-js
+      - vue
+
+  ai@3.4.33(openai@4.71.0(encoding@0.1.13)(zod@3.23.8))(react@18.3.1)(sswr@2.1.0(svelte@5.1.9))(svelte@5.1.9)(vue@3.5.12(typescript@5.6.2))(zod@3.23.8):
+    dependencies:
+      '@ai-sdk/provider': 0.0.26
+      '@ai-sdk/provider-utils': 1.0.22(zod@3.23.8)
+      '@ai-sdk/react': 0.0.70(react@18.3.1)(zod@3.23.8)
+      '@ai-sdk/solid': 0.0.54(zod@3.23.8)
+      '@ai-sdk/svelte': 0.0.57(svelte@5.1.9)(zod@3.23.8)
+      '@ai-sdk/ui-utils': 0.0.50(zod@3.23.8)
+      '@ai-sdk/vue': 0.0.59(vue@3.5.12(typescript@5.6.2))(zod@3.23.8)
       '@opentelemetry/api': 1.9.0
       eventsource-parser: 1.1.2
       json-schema: 0.4.0
@@ -5257,6 +5312,11 @@ snapshots:
   drizzle-zod@0.5.1(drizzle-orm@0.33.0(@cloudflare/workers-types@4.20241106.0)(@libsql/client@0.6.2)(@neondatabase/serverless@0.10.1)(@opentelemetry/api@1.9.0)(@types/pg@8.11.10)(pg@8.13.1)(react@18.3.1))(zod@3.23.8):
     dependencies:
       drizzle-orm: 0.33.0(@cloudflare/workers-types@4.20241106.0)(@libsql/client@0.6.2)(@neondatabase/serverless@0.10.1)(@opentelemetry/api@1.9.0)(@types/pg@8.11.10)(pg@8.13.1)(react@18.3.1)
+      zod: 3.23.8
+
+  drizzle-zod@0.5.1(drizzle-orm@0.36.4(@cloudflare/workers-types@4.20241106.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@neondatabase/serverless@0.10.1)(@opentelemetry/api@1.9.0)(@types/pg@8.11.10)(pg@8.13.1)(react@18.3.1))(zod@3.23.8):
+    dependencies:
+      drizzle-orm: 0.36.4(@cloudflare/workers-types@4.20241106.0)(@libsql/client-wasm@0.14.0)(@libsql/client@0.14.0)(@neondatabase/serverless@0.10.1)(@opentelemetry/api@1.9.0)(@types/pg@8.11.10)(pg@8.13.1)(react@18.3.1)
       zod: 3.23.8
 
   eastasianwidth@0.2.0: {}
@@ -6277,6 +6337,10 @@ snapshots:
     dependencies:
       vue: 3.5.12(typescript@5.5.4)
 
+  swrv@1.0.4(vue@3.5.12(typescript@5.6.2)):
+    dependencies:
+      vue: 3.5.12(typescript@5.6.2)
+
   tar@6.2.1:
     dependencies:
       chownr: 2.0.0
@@ -6416,6 +6480,16 @@ snapshots:
       '@vue/shared': 3.5.12
     optionalDependencies:
       typescript: 5.5.4
+
+  vue@3.5.12(typescript@5.6.2):
+    dependencies:
+      '@vue/compiler-dom': 3.5.12
+      '@vue/compiler-sfc': 3.5.12
+      '@vue/runtime-dom': 3.5.12
+      '@vue/server-renderer': 3.5.12(vue@3.5.12(typescript@5.6.2))
+      '@vue/shared': 3.5.12
+    optionalDependencies:
+      typescript: 5.6.2
 
   web-streams-polyfill@3.3.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,7 +93,7 @@ importers:
         version: 4.20241106.0
       '@fiberplane/hono-otel':
         specifier: latest
-        version: 0.5.0
+        version: 0.5.1
       '@types/node':
         specifier: ^22.2.0
         version: 22.9.0
@@ -194,7 +194,7 @@ importers:
         version: 4.20241106.0
       '@fiberplane/hono-otel':
         specifier: latest
-        version: 0.5.0
+        version: 0.5.1
       drizzle-kit:
         specifier: ^0.28.1
         version: 0.28.1
@@ -231,7 +231,7 @@ importers:
         version: 4.20241106.0
       '@fiberplane/hono-otel':
         specifier: latest
-        version: 0.5.0
+        version: 0.5.1
       drizzle-kit:
         specifier: ^0.28.1
         version: 0.28.1
@@ -363,7 +363,7 @@ importers:
         version: 4.20241106.0
       '@fiberplane/hono-otel':
         specifier: latest
-        version: 0.5.0
+        version: 0.5.1
       drizzle-kit:
         specifier: ^0.28.1
         version: 0.28.1
@@ -1249,8 +1249,8 @@ packages:
   '@fiberplane/hono-otel@0.3.1':
     resolution: {integrity: sha512-E5Gpg06jMngM3gyIjhy4lFuGAv8Qpx0gnglmSgUeuEAkrpAAPy4tHpoFZsFc+gLgoM5+KytoI3MFowgheHjacg==}
 
-  '@fiberplane/hono-otel@0.5.0':
-    resolution: {integrity: sha512-ji54FWoRmhJL1V1YqgwetUKewFzQ/wEV5GWIYWIkMGN3BHg+h0QhtLHITUNcVqMyLxjf5W2I1qo3FcM0EOxayQ==}
+  '@fiberplane/hono-otel@0.5.1':
+    resolution: {integrity: sha512-vdbyFv9YenzSA73jGXUqmNmEdHjd0RPQw5le3eEbGyvq0ggtg1tPr68dM5WQrbJHOZjimmCAeKL9aS9yxQS1kg==}
 
   '@fiberplane/source-analysis@0.1.0':
     resolution: {integrity: sha512-2XI1ZmC0lkG78MMSNHzGQPaP4cFg658egdSU6bjU+FsAzGx0XJgQ7nInhYL7A6qDcTNCvSllYttOuyn6Mm4/Xg==}
@@ -4257,7 +4257,7 @@ snapshots:
       '@types/shimmer': 1.2.0
       shimmer: 1.2.1
 
-  '@fiberplane/hono-otel@0.5.0':
+  '@fiberplane/hono-otel@0.5.1':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/exporter-trace-otlp-http': 0.52.1(@opentelemetry/api@1.9.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -285,11 +285,11 @@ importers:
         specifier: ^4.20241022.0
         version: 4.20241106.0
       '@fiberplane/hono-otel':
-        specifier: ^0.3.1
-        version: 0.3.1
+        specifier: ^0.5.1
+        version: 0.5.1
       '@fiberplane/studio':
         specifier: ^0.11.0
-        version: 0.11.0(@cloudflare/workers-types@4.20241106.0)(@neondatabase/serverless@0.10.1)(@opentelemetry/api@1.9.0)(@types/pg@8.11.10)(encoding@0.1.13)(pg@8.13.1)(react@18.3.1)(sswr@2.1.0(svelte@5.1.9))(svelte@5.1.9)(vue@3.5.12(typescript@5.6.2))
+        version: 0.11.0(@cloudflare/workers-types@4.20241106.0)(@neondatabase/serverless@0.10.1)(@opentelemetry/api@1.9.0)(@types/pg@8.11.10)(encoding@0.1.13)(pg@8.13.1)(react@18.3.1)(sswr@2.1.0(svelte@5.1.9))(svelte@5.1.9)
       '@libsql/client':
         specifier: ^0.14.0
         version: 0.14.0
@@ -3766,16 +3766,6 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
-  '@ai-sdk/vue@0.0.59(vue@3.5.12(typescript@5.6.2))(zod@3.23.8)':
-    dependencies:
-      '@ai-sdk/provider-utils': 1.0.22(zod@3.23.8)
-      '@ai-sdk/ui-utils': 0.0.50(zod@3.23.8)
-      swrv: 1.0.4(vue@3.5.12(typescript@5.6.2))
-    optionalDependencies:
-      vue: 3.5.12(typescript@5.6.2)
-    transitivePeerDependencies:
-      - zod
-
   '@ampproject/remapping@2.3.0':
     dependencies:
       '@jridgewell/gen-mapping': 0.3.5
@@ -4278,7 +4268,7 @@ snapshots:
       type-fest: 4.28.1
       typescript: 5.6.2
 
-  '@fiberplane/studio@0.11.0(@cloudflare/workers-types@4.20241106.0)(@neondatabase/serverless@0.10.1)(@opentelemetry/api@1.9.0)(@types/pg@8.11.10)(encoding@0.1.13)(pg@8.13.1)(react@18.3.1)(sswr@2.1.0(svelte@5.1.9))(svelte@5.1.9)(vue@3.5.12(typescript@5.6.2))':
+  '@fiberplane/studio@0.11.0(@cloudflare/workers-types@4.20241106.0)(@neondatabase/serverless@0.10.1)(@opentelemetry/api@1.9.0)(@types/pg@8.11.10)(encoding@0.1.13)(pg@8.13.1)(react@18.3.1)(sswr@2.1.0(svelte@5.1.9))(svelte@5.1.9)':
     dependencies:
       '@ai-sdk/anthropic': 0.0.51(zod@3.23.8)
       '@ai-sdk/mistral': 0.0.42(zod@3.23.8)
@@ -4291,7 +4281,7 @@ snapshots:
       '@iarna/toml': 2.2.5
       '@langchain/core': 0.2.36(openai@4.71.0(encoding@0.1.13)(zod@3.23.8))
       '@libsql/client': 0.6.2
-      ai: 3.4.33(openai@4.71.0(encoding@0.1.13)(zod@3.23.8))(react@18.3.1)(sswr@2.1.0(svelte@5.1.9))(svelte@5.1.9)(vue@3.5.12(typescript@5.6.2))(zod@3.23.8)
+      ai: 3.4.33(openai@4.71.0(encoding@0.1.13)(zod@3.23.8))(react@18.3.1)(sswr@2.1.0(svelte@5.1.9))(svelte@5.1.9)(vue@3.5.12(typescript@5.5.4))(zod@3.23.8)
       chalk: 5.3.0
       consola: 3.2.3
       dotenv: 16.4.5
@@ -5013,12 +5003,6 @@ snapshots:
       '@vue/shared': 3.5.12
       vue: 3.5.12(typescript@5.5.4)
 
-  '@vue/server-renderer@3.5.12(vue@3.5.12(typescript@5.6.2))':
-    dependencies:
-      '@vue/compiler-ssr': 3.5.12
-      '@vue/shared': 3.5.12
-      vue: 3.5.12(typescript@5.6.2)
-
   '@vue/shared@3.5.12': {}
 
   abort-controller@3.0.0:
@@ -5048,31 +5032,6 @@ snapshots:
       '@ai-sdk/svelte': 0.0.57(svelte@5.1.9)(zod@3.23.8)
       '@ai-sdk/ui-utils': 0.0.50(zod@3.23.8)
       '@ai-sdk/vue': 0.0.59(vue@3.5.12(typescript@5.5.4))(zod@3.23.8)
-      '@opentelemetry/api': 1.9.0
-      eventsource-parser: 1.1.2
-      json-schema: 0.4.0
-      jsondiffpatch: 0.6.0
-      secure-json-parse: 2.7.0
-      zod-to-json-schema: 3.23.5(zod@3.23.8)
-    optionalDependencies:
-      openai: 4.71.0(encoding@0.1.13)(zod@3.23.8)
-      react: 18.3.1
-      sswr: 2.1.0(svelte@5.1.9)
-      svelte: 5.1.9
-      zod: 3.23.8
-    transitivePeerDependencies:
-      - solid-js
-      - vue
-
-  ai@3.4.33(openai@4.71.0(encoding@0.1.13)(zod@3.23.8))(react@18.3.1)(sswr@2.1.0(svelte@5.1.9))(svelte@5.1.9)(vue@3.5.12(typescript@5.6.2))(zod@3.23.8):
-    dependencies:
-      '@ai-sdk/provider': 0.0.26
-      '@ai-sdk/provider-utils': 1.0.22(zod@3.23.8)
-      '@ai-sdk/react': 0.0.70(react@18.3.1)(zod@3.23.8)
-      '@ai-sdk/solid': 0.0.54(zod@3.23.8)
-      '@ai-sdk/svelte': 0.0.57(svelte@5.1.9)(zod@3.23.8)
-      '@ai-sdk/ui-utils': 0.0.50(zod@3.23.8)
-      '@ai-sdk/vue': 0.0.59(vue@3.5.12(typescript@5.6.2))(zod@3.23.8)
       '@opentelemetry/api': 1.9.0
       eventsource-parser: 1.1.2
       json-schema: 0.4.0
@@ -6337,10 +6296,6 @@ snapshots:
     dependencies:
       vue: 3.5.12(typescript@5.5.4)
 
-  swrv@1.0.4(vue@3.5.12(typescript@5.6.2)):
-    dependencies:
-      vue: 3.5.12(typescript@5.6.2)
-
   tar@6.2.1:
     dependencies:
       chownr: 2.0.0
@@ -6480,16 +6435,6 @@ snapshots:
       '@vue/shared': 3.5.12
     optionalDependencies:
       typescript: 5.5.4
-
-  vue@3.5.12(typescript@5.6.2):
-    dependencies:
-      '@vue/compiler-dom': 3.5.12
-      '@vue/compiler-sfc': 3.5.12
-      '@vue/runtime-dom': 3.5.12
-      '@vue/server-renderer': 3.5.12(vue@3.5.12(typescript@5.6.2))
-      '@vue/shared': 3.5.12
-    optionalDependencies:
-      typescript: 5.6.2
 
   web-streams-polyfill@3.3.3: {}
 


### PR DESCRIPTION
Mostly last touches, and feedback implementation:
- include formatted errors in invalid payload response
- fix invalid subquery implementation
- switch controller typing from constructed to union of inferred
  - couldn't prevent inference from breaking down
- use drizzle-zod to create zod schemas
- revert makeBodyValidator to consume Zod schema
  - error consumers need the error type narrowing
- add color-scheme `meta` tag
- clarify some function names
- add comments and jsdocs
- update hono client version
- add some color to the readme