### PR TITLE
Add typescript as a dev dep back to the templates

### DIFF
--- a/templates/base-supa/package.json
+++ b/templates/base-supa/package.json
@@ -22,6 +22,7 @@
     "drizzle-kit": "^0.28.1",
     "drizzle-seed": "^0.1.2",
     "tsx": "^4.19.2",
+    "typescript": "^5.5.4",
     "wrangler": "3.92.0"
   }
 }

--- a/templates/base-supa/package.json
+++ b/templates/base-supa/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20241205.0",
-    "@fiberplane/hono-otel": "latest",
+    "@fiberplane/hono-otel": "^0.6.1",
     "drizzle-kit": "^0.28.1",
     "drizzle-seed": "^0.1.2",
     "tsx": "^4.19.2",

--- a/templates/base/package.json
+++ b/templates/base/package.json
@@ -22,6 +22,7 @@
     "drizzle-kit": "^0.28.1",
     "drizzle-seed": "^0.1.2",
     "tsx": "^4.19.2",
+    "typescript": "^5.5.4",
     "wrangler": "3.92.0"
   }
 }

--- a/templates/base/package.json
+++ b/templates/base/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20241205.0",
-    "@fiberplane/hono-otel": "latest",
+    "@fiberplane/hono-otel": "^0.6.1",
     "drizzle-kit": "^0.28.1",
     "drizzle-seed": "^0.1.2",
     "tsx": "^4.19.2",

--- a/templates/d1/package.json
+++ b/templates/d1/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20241205.0",
-    "@fiberplane/hono-otel": "latest",
+    "@fiberplane/hono-otel": "^0.6.1",
     "@libsql/client": "^0.14.0",
     "drizzle-kit": "^0.28.1",
     "drizzle-seed": "^0.1.2",

--- a/templates/d1/package.json
+++ b/templates/d1/package.json
@@ -24,6 +24,7 @@
     "drizzle-kit": "^0.28.1",
     "drizzle-seed": "^0.1.2",
     "tsx": "^4.19.2",
+    "typescript": "^5.5.4",
     "wrangler": "3.92.0"
   }
 }


### PR DESCRIPTION
We need typescript as a dev dependency for the static analysis bits 

Also I changed our templates to not rely on a `latest` tag for the hono-otel lib