### PR TITLE
Update and pin neon sdk and add an error logging escape hatch

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-honc-app",
   "type": "module",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "An interactive CLI to create modular typesafe data APIs using TypeScript",
   "scripts": {
     "build": "pnpm clean && tsup",
@@ -26,7 +26,7 @@
   "dependencies": {
     "@clack/core": "^0.3.4",
     "@clack/prompts": "^0.7.0",
-    "@neondatabase/api-client": "^1.10.3",
+    "@neondatabase/api-client": "1.11.2",
     "giget": "^1.2.3",
     "open": "^10.1.0",
     "oslo": "^1.2.1",

--- a/cli/src/actions/database/neon.ts
+++ b/cli/src/actions/database/neon.ts
@@ -143,9 +143,10 @@ async function createNewProject(neon: Api<unknown>): Promise<string | symbol> {
 
 async function selectProjectBranch(
   neon: Api<unknown>,
-  project: string,
+  projectId: string,
 ): Promise<string | symbol> {
-  const branches = (await neon.listProjectBranches(project)).data.branches;
+  const branches = (await neon.listProjectBranches({ projectId })).data
+    .branches;
   const branchOptions = branches.map((branch) => ({
     label: branch.name,
     value: branch.id,

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -56,6 +56,15 @@ export function handleError(error: Error | CodeGenError) {
     log.info("Continuing...");
   } else {
     log.error(`exiting with an error: ${error.message}`);
+    // HACK - Allow us to log the error in more depth if `CHA_LOG_LEVEL` is set to `debug`
+    if (process?.env?.CHA_LOG_LEVEL === "debug") {
+      console.error("\n\n*********LOGGING VERBOSE ERROR*********\n");
+      console.error(error);
+      console.error(
+        "\n\n*********LOGGING VERBOSE ERROR AGAIN, BUT AS JSON*********\n",
+      );
+      console.error(JSON.stringify(error, null, 2));
+    }
     process.exit(1);
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: ^0.7.0
         version: 0.7.0
       '@neondatabase/api-client':
-        specifier: ^1.10.3
-        version: 1.10.3
+        specifier: 1.11.2
+        version: 1.11.2
       giget:
         specifier: ^1.2.3
         version: 1.2.3
@@ -1321,8 +1321,8 @@ packages:
   '@neon-rs/load@0.0.4':
     resolution: {integrity: sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==}
 
-  '@neondatabase/api-client@1.10.3':
-    resolution: {integrity: sha512-rqCtsR8OYATD6bCdv4Qj/zYNAEHYZ93sYktWIDl1kdXSzrxt+SkHDNrp4zQFsnnfjiLg527l6oRJ8rd8H72ZiA==}
+  '@neondatabase/api-client@1.11.2':
+    resolution: {integrity: sha512-W9M5MQGAGnArlzzg5mWWhkt9EIZpTG/q1Z3a4rgGUPh8t6S6rXaREpnMeQTbFGoQLdD7zlogS8WD/tb2ADM3Zg==}
 
   '@neondatabase/serverless@0.10.1':
     resolution: {integrity: sha512-Upn555uEYL/q8aqMdPSviggNWeeZLCl5FhCIs7A4hmshfoOAAfML+Sqbcxr+Re2WZN5+hpyM9JClImXnBuhuXw==}
@@ -1919,8 +1919,8 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  axios@1.7.7:
-    resolution: {integrity: sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==}
+  axios@1.7.9:
+    resolution: {integrity: sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -3957,9 +3957,9 @@ snapshots:
 
   '@neon-rs/load@0.0.4': {}
 
-  '@neondatabase/api-client@1.10.3':
+  '@neondatabase/api-client@1.11.2':
     dependencies:
-      axios: 1.7.7
+      axios: 1.7.9
     transitivePeerDependencies:
       - debug
 
@@ -4514,7 +4514,7 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios@1.7.7:
+  axios@1.7.9:
     dependencies:
       follow-redirects: 1.15.9
       form-data: 4.0.0


### PR DESCRIPTION
> **This branch has already been released as latest, version 1.3.2**

There were issues with (at least for me and @Nlea) doing the authorized Neon CLI flow. We could log in, but project branches would never show up.

Turns out it had to do with an update to the neon api sdk. Not sure why pnpm resolved the sdk differently than npm (for me), but I figured this would be a good time to:

- update our version of the neon api sdk
- add an optional flag to log terminal errors to the console (so we can debug more effectively)
- **pin** our version of the neon sdk so there are no surprising backwards incompatible changes in the future

***

> **This branch has already been released as latest, version 1.3.2**