### PR TITLE
Add a README to the examples folder

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,28 @@
+# HONC Stack Example Projects
+
+This directory contains example projects built with the HONC stack (Hono, OpenTelemetry, Neon/D1, Cloudflare), showcasing different use cases and integrations.
+
+## Projects
+
+### 🎯 [Placegoose](./placegoose)
+A REST API service providing goose-themed data. Perfect for learning how to build and structure REST APIs with the HONC stack. Uses Cloudflare D1 for data storage.
+
+- Blog post: https://fiberplane.com/blog/placegoose-guide/
+
+### 🤖 [Retrieval Augmented Goose](./cf-retrieval-augmented-goose)
+A RAG (Retrieval Augmented Generation) example that uses Cloudflare docs as a knowledge base. Demonstrates vector embeddings and AI integration with the HONC stack.
+
+- Blog: https://fiberplane.com/blog/retrieval-augmented-geese/
+
+### 📊 [Website Uptime Monitor](./uptime-monitor)
+A serverless monitoring application that tracks website uptime. Features configurable health checks, response time tracking, and a web interface. Uses Cloudflare D1 and Durable Objects.
+
+- Blog post: https://fiberplane.com/blog/honc-up-time-monitor/
+
+### 🎨 [Honcanator](./honcanator)
+An AI-powered goose image generator that creates comic/anime style goose images using Cloudflare AI. Stores images in R2 and metadata in Neon Postgres.
+
+- Blog: https://fiberplane.com/blog/ai-goose-generator/
+
+### 😄 [Goose Joke Generator](./goose-joke-generator)
+A web app that generates (terrible) goose-themed jokes using Cloudflare AI. Stores jokes in a Neon Postgres database and includes rate limiting functionality.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,28 +1,82 @@
-# HONC Stack Example Projects
+# :goose: HONC Stack Example Projects :goose:
 
-This directory contains example projects built with the HONC stack (Hono, OpenTelemetry, Neon/D1, Cloudflare), showcasing different use cases and integrations.
+This directory contains example projects built with the HONC stack, showcasing different use cases, patterns, and integrations.
 
 ## Projects
 
 ### 🎯 [Placegoose](./placegoose)
-A REST API service providing goose-themed data. Perfect for learning how to build and structure REST APIs with the HONC stack. Uses Cloudflare D1 for data storage.
+A mock REST API service providing goose-themed data, similar to JSON Placeholder. Great for seeing how to use middleware for validation in Hono.
 
 - Blog post: https://fiberplane.com/blog/placegoose-guide/
+- See it live: https://placegoose.fp.dev
+
+<details>
+<summary>Integrations</summary>
+- Cloudflare D1 for data storage
+- Cloudflare Asset Bindings for Workers
+- UI: Markdown rendered with Remark
+</details>
 
 ### 🤖 [Retrieval Augmented Goose](./cf-retrieval-augmented-goose)
-A RAG (Retrieval Augmented Generation) example that uses Cloudflare docs as a knowledge base. Demonstrates vector embeddings and AI integration with the HONC stack.
+A RAG (Retrieval Augmented Generation) example that uses Cloudflare docs as a knowledge base. Demonstrates vector embeddings and AI integration with the HONC stack using Neon Postgres.
 
 - Blog: https://fiberplane.com/blog/retrieval-augmented-geese/
+- See it live: https://cf-retrieval-augmented-goose.mies.workers.dev
+
+<details>
+<summary>Integrations</summary>
+- Neon serverless Postgres for data storage and vector search
+- OpenAI for embeddings generation
+- UI: SSR with hono/jsx and Fiberplane's "ascuii" SSR ui components
+</details>
+<details>
+
 
 ### 📊 [Website Uptime Monitor](./uptime-monitor)
 A serverless monitoring application that tracks website uptime. Features configurable health checks, response time tracking, and a web interface. Uses Cloudflare D1 and Durable Objects.
 
 - Blog post: https://fiberplane.com/blog/honc-up-time-monitor/
 
+<details>
+<summary>Integrations</summary>
+- Cloudflare D1 for data storage
+- Cloudflare Durable Objects for serverless state
+- UI: SSR with hono/jsx
+</details>
+<details>
+
 ### 🎨 [Honcanator](./honcanator)
 An AI-powered goose image generator that creates comic/anime style goose images using Cloudflare AI. Stores images in R2 and metadata in Neon Postgres.
 
-- Blog: https://fiberplane.com/blog/ai-goose-generator/
+- Blog post: https://fiberplane.com/blog/ai-goose-generator/
+
+<details>
+<summary>Integrations</summary>
+- Neon serverless Postgres for relational data storage
+- Cloudflare R2 for blob storage
+- Cloudflare AI for image generation (Flux-1-Schnell)
+</details>
+<details>
+
+### 🪿 [Goose Review Bot](./goose-review-bot)
+
+A GitHub PR review bot that provides "goosey" code reviews using Claude. Built with Neon Postgres and Cloudflare Workers.
+
+<details>
+<summary>Integrations</summary>
+- GitHub Octokit to handle webhooks and pull requests
+- Claude (Anthropic) to provide code reviews
+</details>
+<details>
 
 ### 😄 [Goose Joke Generator](./goose-joke-generator)
 A web app that generates (terrible) goose-themed jokes using Cloudflare AI. Stores jokes in a Neon Postgres database and includes rate limiting functionality.
+
+- See it live: https://goose-jokes.fp.dev
+
+<details>
+<summary>Integrations</summary>
+- Neon serverless Postgres for data storage
+- Cloudflare AI (Llama-3.1-8B-Instruct)
+</details>
+<details>


### PR DESCRIPTION
This PR makes the examples folder a little more contextual, esp if someone clicks into it on GitHub.

Also also, if we ever link to the examples folder it'd be nice to have a README on that page. 