### PR TITLE
Template fixes after `hono-openapi` merge

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -90,7 +90,7 @@ async function main() {
   // Update the project name in the package.json file and wrangler.toml file
   updateProjectName(context);
 
-  // Add the default FPX_ENDPOINT environment variable to the .dev.vars file
+  // Add a (gitignored) .dev.vars file
   touchDevVars(context);
 
   // Add a reminder of remaining database setup steps, if necessary

--- a/templates/base-openapi/src/index.ts
+++ b/templates/base-openapi/src/index.ts
@@ -36,8 +36,8 @@ app.use(async (c, next) => {
 // by chaining `openapi` on the zod schema definitions
 const UserSchema = z
   .object({
-    id: z.number().openapi({
-      example: 1,
+    id: z.string().uuid().openapi({
+      example: "123e4567-e89b-12d3-a456-426614174000",
     }),
     name: z.string().openapi({
       example: "Nikita",
@@ -76,7 +76,7 @@ apiRouter
         201: {
           content: {
             "application/json": {
-              schema: UserSchema,
+              schema: resolver(UserSchema),
             },
           },
           description: "User created successfully",

--- a/templates/base-supa-openapi/README.md
+++ b/templates/base-supa-openapi/README.md
@@ -10,6 +10,14 @@ There is also an [Awesome HONC collection](https://github.com/fiberplane/awesome
 
 Make sure you have Supabase set up and configured with your database. Create a .dev.vars file with the `DATABASE_URL` key and value (see: `.dev.vars.example`).
 
+If you're working locally, your `DATABASE_URL` will be something like:
+
+```sh
+DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
+```
+
+
+
 ### Project structure
 
 ```#

--- a/templates/base-supa-openapi/src/db/schema.ts
+++ b/templates/base-supa-openapi/src/db/schema.ts
@@ -1,9 +1,11 @@
-import { jsonb, pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
+import { jsonb, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
 
 export type NewUser = typeof users.$inferInsert;
 
 export const users = pgTable("users", {
-  id: serial("id").primaryKey(),
+  // NOTE - We use a random UUID here, instead of a `serial`, because at the time of writing,
+  //        drizzle-seed messes with the auto-incrementing ID in Postgres. not sure why yet.
+  id: uuid("id").defaultRandom().primaryKey(),
   name: text("name").notNull(),
   email: text("email").notNull(),
   settings: jsonb("settings"),

--- a/templates/base-supa-openapi/src/index.ts
+++ b/templates/base-supa-openapi/src/index.ts
@@ -36,8 +36,8 @@ app.use(async (c, next) => {
 // by chaining `openapi` on the zod schema definitions
 const UserSchema = z
   .object({
-    id: z.number().openapi({
-      example: 1,
+    id: z.string().uuid().openapi({
+      example: "123e4567-e89b-12d3-a456-426614174000",
     }),
     name: z.string().openapi({
       example: "Paul",
@@ -113,7 +113,7 @@ const apiRouter = new Hono<{ Bindings: Bindings; Variables: Variables }>()
     describeRoute({
       responses: {
         200: {
-          content: { "application/json": { schema: UserSchema } },
+          content: { "application/json": { schema: resolver(UserSchema) } },
           description: "User fetched successfully",
         },
       },
@@ -121,8 +121,8 @@ const apiRouter = new Hono<{ Bindings: Bindings; Variables: Variables }>()
     zValidator(
       "param",
       z.object({
-        id: z.coerce.number().openapi({
-          example: 1,
+        id: z.string().uuid().openapi({
+          example: "123e4567-e89b-12d3-a456-426614174000",
         }),
       }),
     ),
@@ -144,7 +144,7 @@ app
     describeRoute({
       responses: {
         200: {
-          content: { "text/plain": { schema: z.string() } },
+          content: { "text/plain": { schema: resolver(z.string()) } },
           description: "Root fetched successfully",
         },
       },

--- a/templates/base-supa/README.md
+++ b/templates/base-supa/README.md
@@ -12,6 +12,12 @@ This template uses Drizzle to query a Supabase (postgres) database. It also has 
 
 Make sure you have Supabase set up and configured with your database. Create a .dev.vars file with the `DATABASE_URL` key and value (see: `.dev.vars.example`).
 
+If you're working locally, your `DATABASE_URL` will be something like:
+
+```sh
+DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
+```
+
 ### Project structure
 
 ```#

--- a/templates/d1-openapi/src/db/schema.ts
+++ b/templates/d1-openapi/src/db/schema.ts
@@ -4,7 +4,8 @@ import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 export type NewUser = typeof users.$inferInsert;
 
 export const users = sqliteTable("users", {
-  id: integer("id", { mode: "number" }).primaryKey(),
+  // .primaryKey() must be chained before $defaultFn
+  id: text().primaryKey().$defaultFn(() => crypto.randomUUID()),
   name: text("name").notNull(),
   email: text("email").notNull(),
   createdAt: text("created_at").notNull().default(sql`(CURRENT_TIMESTAMP)`),

--- a/templates/d1-openapi/src/index.ts
+++ b/templates/d1-openapi/src/index.ts
@@ -34,8 +34,8 @@ app.use(async (c, next) => {
 // by chaining `openapi` on the zod schema definitions
 const UserSchema = z
   .object({
-    id: z.number().openapi({
-      example: 1,
+    id: z.string().uuid().openapi({
+      example: "123e4567-e89b-12d3-a456-426614174000",
     }),
     name: z.string().openapi({
       example: "Matthew",
@@ -119,8 +119,8 @@ const apiRouter = new Hono<{ Bindings: Bindings; Variables: Variables }>()
     zValidator(
       "param",
       z.object({
-        id: z.coerce.number().openapi({
-          example: 1,
+        id: z.string().uuid().openapi({
+          example: "123e4567-e89b-12d3-a456-426614174000",
         }),
       }),
     ),

--- a/templates/d1-openapi/src/index.ts
+++ b/templates/d1-openapi/src/index.ts
@@ -142,7 +142,7 @@ app
     describeRoute({
       responses: {
         200: {
-          content: { "text/plain": { schema: z.string() } },
+          content: { "text/plain": { schema: resolver(z.string()) } },
           description: "Root fetched successfully",
         },
       },


### PR DESCRIPTION
- Fix use of serial in supabase template (issues with seeding)
- Use `resolver` to fix typescript errors in some sections of hono-openapi code
- Make the user table use `uuid` for the id to avoid issues with drizzle seed
- Add a little helper blurb to supabase templates