### PR TITLE
Validation enhancements

### DIFF
--- a/templates/base-openapi/package.json
+++ b/templates/base-openapi/package.json
@@ -13,7 +13,6 @@
   },
   "dependencies": {
     "@fiberplane/hono": "0.5.2",
-    "@hono/zod-validator": "^0.4.3",
     "@neondatabase/serverless": "^0.10.4",
     "dotenv": "^16.4.7",
     "drizzle-orm": "^0.39.3",

--- a/templates/base-openapi/src/dtos/index.ts
+++ b/templates/base-openapi/src/dtos/index.ts
@@ -4,12 +4,14 @@ import "zod-openapi/extend";
 import * as schema from "../db/schema";
 
 export const ZUserInsert = createInsertSchema(schema.users, {
-  name: (schema) => schema.openapi({ 
-    example: "Goose McCloud",
-  }),
-  email: (schema) => schema.email().openapi({ 
-    example: "goose@honc.dev",
-  }),
+  name: (schema) =>
+    schema.openapi({
+      example: "Goose McCloud",
+    }),
+  email: (schema) =>
+    schema.email().openapi({
+      example: "goose@honc.dev",
+    }),
 })
   .pick({
     name: true,
@@ -20,21 +22,26 @@ export const ZUserInsert = createInsertSchema(schema.users, {
   });
 
 export const ZUserSelect = createSelectSchema(schema.users, {
-  id: (schema) => schema.uuid().openapi({ 
-    example: "3e0bb3d0-2074-4a1e-6263-d13dd10cb0cf",
-  }), 
-  name: (schema) => schema.openapi({ 
-    example: "Goose McCloud",
-  }),
-  email: (schema) => schema.email().openapi({ 
-    example: "goose@honc.dev",
-  }),
-  createdAt: (schema) => schema.openapi({
-    example: "2026-03-29T11:22:48.462Z",
-  }),
-  updatedAt: (schema) => schema.openapi({ 
-    example: "2026-03-29T11:22:48.462Z",
-  }),
+  id: (schema) =>
+    schema.uuid().openapi({
+      example: "3e0bb3d0-2074-4a1e-6263-d13dd10cb0cf",
+    }),
+  name: (schema) =>
+    schema.openapi({
+      example: "Goose McCloud",
+    }),
+  email: (schema) =>
+    schema.email().openapi({
+      example: "goose@honc.dev",
+    }),
+  createdAt: (schema) =>
+    schema.openapi({
+      example: "2026-03-29T11:22:48.462Z",
+    }),
+  updatedAt: (schema) =>
+    schema.openapi({
+      example: "2026-03-29T11:22:48.462Z",
+    }),
 }).openapi({
   ref: "UserSelect",
 });

--- a/templates/base-openapi/src/dtos/index.ts
+++ b/templates/base-openapi/src/dtos/index.ts
@@ -3,7 +3,14 @@ import { z } from "zod";
 import "zod-openapi/extend";
 import * as schema from "../db/schema";
 
-export const ZUserInsert = createInsertSchema(schema.users)
+export const ZUserInsert = createInsertSchema(schema.users, {
+  name: (schema) => schema.openapi({ 
+    example: "Goose McCloud",
+  }),
+  email: (schema) => schema.email().openapi({ 
+    example: "goose@honc.dev",
+  }),
+})
   .pick({
     name: true,
     email: true,
@@ -12,7 +19,23 @@ export const ZUserInsert = createInsertSchema(schema.users)
     ref: "UserInsert",
   });
 
-export const ZUserSelect = createSelectSchema(schema.users).openapi({
+export const ZUserSelect = createSelectSchema(schema.users, {
+  id: (schema) => schema.uuid().openapi({ 
+    example: "3e0bb3d0-2074-4a1e-6263-d13dd10cb0cf",
+  }), 
+  name: (schema) => schema.openapi({ 
+    example: "Goose McCloud",
+  }),
+  email: (schema) => schema.email().openapi({ 
+    example: "goose@honc.dev",
+  }),
+  createdAt: (schema) => schema.openapi({
+    example: "2026-03-29T11:22:48.462Z",
+  }),
+  updatedAt: (schema) => schema.openapi({ 
+    example: "2026-03-29T11:22:48.462Z",
+  }),
+}).openapi({
   ref: "UserSelect",
 });
 

--- a/templates/base-supa-openapi/package.json
+++ b/templates/base-supa-openapi/package.json
@@ -13,7 +13,6 @@
   },
   "dependencies": {
     "@fiberplane/hono": "0.5.2",
-    "@hono/zod-validator": "^0.4.3",
     "dotenv": "^16.4.5",
     "drizzle-orm": "^0.39.3",
     "drizzle-zod": "^0.7.1",

--- a/templates/base-supa-openapi/package.json
+++ b/templates/base-supa-openapi/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "@cloudflare/workers-types": "^4.20250321.0",
+    "@types/node": "^22.15.18",
     "drizzle-kit": "^0.30.4",
     "drizzle-seed": "^0.3.1",
     "tsx": "^4.19.2",

--- a/templates/base-supa-openapi/src/dtos/index.ts
+++ b/templates/base-supa-openapi/src/dtos/index.ts
@@ -3,7 +3,14 @@ import { z } from "zod";
 import "zod-openapi/extend";
 import * as schema from "../db/schema";
 
-export const ZUserInsert = createInsertSchema(schema.users)
+export const ZUserInsert = createInsertSchema(schema.users, {
+  name: (schema) => schema.openapi({ 
+    example: "Goose McCloud"
+  }),
+  email: (schema) => schema.email().openapi({ 
+    example: "goose@honc.dev"
+  }),
+})
   .pick({
     name: true,
     email: true,
@@ -12,7 +19,23 @@ export const ZUserInsert = createInsertSchema(schema.users)
     ref: "UserInsert",
   });
 
-export const ZUserSelect = createSelectSchema(schema.users).openapi({
+export const ZUserSelect = createSelectSchema(schema.users, {
+  id: (schema) => schema.uuid().openapi({ 
+    example: "3e0bb3d0-2074-4a1e-6263-d13dd10cb0cf" 
+  }), 
+  name: (schema) => schema.openapi({ 
+    example: "Goose McCloud" 
+  }),
+  email: (schema) => schema.email().openapi({ 
+    example: "goose@honc.dev" 
+  }),
+  createdAt: (schema) => schema.openapi({
+    example: "2026-03-29T11:22:48.462Z",
+  }),
+  updatedAt: (schema) => schema.openapi({
+    example: "2026-03-29T11:22:48.462Z",
+  }),
+}).openapi({
   ref: "UserSelect",
 });
 

--- a/templates/base-supa-openapi/src/dtos/index.ts
+++ b/templates/base-supa-openapi/src/dtos/index.ts
@@ -4,12 +4,14 @@ import "zod-openapi/extend";
 import * as schema from "../db/schema";
 
 export const ZUserInsert = createInsertSchema(schema.users, {
-  name: (schema) => schema.openapi({ 
-    example: "Goose McCloud"
-  }),
-  email: (schema) => schema.email().openapi({ 
-    example: "goose@honc.dev"
-  }),
+  name: (schema) =>
+    schema.openapi({
+      example: "Goose McCloud",
+    }),
+  email: (schema) =>
+    schema.email().openapi({
+      example: "goose@honc.dev",
+    }),
 })
   .pick({
     name: true,
@@ -20,21 +22,26 @@ export const ZUserInsert = createInsertSchema(schema.users, {
   });
 
 export const ZUserSelect = createSelectSchema(schema.users, {
-  id: (schema) => schema.uuid().openapi({ 
-    example: "3e0bb3d0-2074-4a1e-6263-d13dd10cb0cf" 
-  }), 
-  name: (schema) => schema.openapi({ 
-    example: "Goose McCloud" 
-  }),
-  email: (schema) => schema.email().openapi({ 
-    example: "goose@honc.dev" 
-  }),
-  createdAt: (schema) => schema.openapi({
-    example: "2026-03-29T11:22:48.462Z",
-  }),
-  updatedAt: (schema) => schema.openapi({
-    example: "2026-03-29T11:22:48.462Z",
-  }),
+  id: (schema) =>
+    schema.uuid().openapi({
+      example: "3e0bb3d0-2074-4a1e-6263-d13dd10cb0cf",
+    }),
+  name: (schema) =>
+    schema.openapi({
+      example: "Goose McCloud",
+    }),
+  email: (schema) =>
+    schema.email().openapi({
+      example: "goose@honc.dev",
+    }),
+  createdAt: (schema) =>
+    schema.openapi({
+      example: "2026-03-29T11:22:48.462Z",
+    }),
+  updatedAt: (schema) =>
+    schema.openapi({
+      example: "2026-03-29T11:22:48.462Z",
+    }),
 }).openapi({
   ref: "UserSelect",
 });

--- a/templates/base-supa/package.json
+++ b/templates/base-supa/package.json
@@ -23,7 +23,6 @@
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "@cloudflare/workers-types": "^4.20250321.0",
-    "@fiberplane/hono-otel": "^0.6.2",
     "drizzle-kit": "^0.30.4",
     "drizzle-seed": "^0.3.1",
     "tsx": "^4.19.2",

--- a/templates/base-supa/package.json
+++ b/templates/base-supa/package.json
@@ -15,6 +15,7 @@
     "@fiberplane/hono": "0.5.2",
     "dotenv": "^16.4.7",
     "drizzle-orm": "^0.39.3",
+    "drizzle-zod": "^0.7.1",
     "hono": "^4.7.0",
     "postgres": "^3.4.5",
     "zod": "^3.23.8"

--- a/templates/base-supa/src/dtos/index.ts
+++ b/templates/base-supa/src/dtos/index.ts
@@ -3,14 +3,14 @@ import { z } from "zod";
 import * as schema from "../db/schema";
 
 export const ZUserInsert = createInsertSchema(schema.users, {
-  email: (schema) => schema.email()
+  email: (schema) => schema.email(),
 }).pick({
   name: true,
   email: true,
 });
 
 export const ZUserSelect = createSelectSchema(schema.users, {
-  id: (schema) => schema.uuid(), 
+  id: (schema) => schema.uuid(),
   email: (schema) => schema.email(),
 });
 

--- a/templates/base-supa/src/dtos/index.ts
+++ b/templates/base-supa/src/dtos/index.ts
@@ -1,0 +1,19 @@
+import { createInsertSchema, createSelectSchema } from "drizzle-zod";
+import { z } from "zod";
+import * as schema from "../db/schema";
+
+export const ZUserInsert = createInsertSchema(schema.users, {
+  email: (schema) => schema.email()
+}).pick({
+  name: true,
+  email: true,
+});
+
+export const ZUserSelect = createSelectSchema(schema.users, {
+  id: (schema) => schema.uuid(), 
+  email: (schema) => schema.email(),
+});
+
+export const ZUserByIDParams = z.object({
+  id: z.string().uuid(),
+});

--- a/templates/base-supa/src/index.ts
+++ b/templates/base-supa/src/index.ts
@@ -6,8 +6,8 @@ import { createMiddleware } from "hono/factory";
 import { HTTPException } from "hono/http-exception";
 import postgres from "postgres";
 import * as schema from "./db/schema";
-import { zodValidator } from "./middleware/validator";
 import { ZUserByIDParams, ZUserInsert } from "./dtos";
+import { zodValidator } from "./middleware/validator";
 
 const initDb = createMiddleware<{
   Bindings: {
@@ -34,39 +34,31 @@ const api = new Hono()
 
     return c.json(users);
   })
-  .post(
-    "/users",
-    zodValidator("json", ZUserInsert),
-    async (c) => {
-      const db = c.var.db;
-      const { name, email } = c.req.valid("json");
+  .post("/users", zodValidator("json", ZUserInsert), async (c) => {
+    const db = c.var.db;
+    const { name, email } = c.req.valid("json");
 
-      const [newUser] = await db
-        .insert(schema.users)
-        .values({
-          name: name,
-          email: email,
-        })
-        .returning();
+    const [newUser] = await db
+      .insert(schema.users)
+      .values({
+        name: name,
+        email: email,
+      })
+      .returning();
 
-      return c.json(newUser, 201);
-    }
-  )
-  .get(
-    "/users/:id",
-    zodValidator("param", ZUserByIDParams),
-    async (c) => {
-      const db = c.var.db;
-      const { id } = c.req.valid("param");
+    return c.json(newUser, 201);
+  })
+  .get("/users/:id", zodValidator("param", ZUserByIDParams), async (c) => {
+    const db = c.var.db;
+    const { id } = c.req.valid("param");
 
-      const [user] = await db
-        .select()
-        .from(schema.users)
-        .where(eq(schema.users.id, id));
+    const [user] = await db
+      .select()
+      .from(schema.users)
+      .where(eq(schema.users.id, id));
 
-      return c.json(user);
-    }
-  );
+    return c.json(user);
+  });
 
 const app = new Hono()
   .get("/", (c) => {

--- a/templates/base-supa/src/middleware/validator.ts
+++ b/templates/base-supa/src/middleware/validator.ts
@@ -1,6 +1,6 @@
 import type { ValidationTargets } from "hono";
-import { validator } from "hono/validator";
 import { HTTPException } from "hono/http-exception";
+import { validator } from "hono/validator";
 import type { z } from "zod";
 
 /**

--- a/templates/base-supa/src/middleware/validator.ts
+++ b/templates/base-supa/src/middleware/validator.ts
@@ -1,0 +1,31 @@
+import type { ValidationTargets } from "hono";
+import { validator } from "hono/validator";
+import { HTTPException } from "hono/http-exception";
+import type { z } from "zod";
+
+/**
+ * A wrapper around `hono/validator` configured for Zod schemas
+ * that standardizes error handling.
+ * @param target The relevant Hono validation target, e.g., "json" or "query"
+ * @param schema A Zod schema used to validate the selected target
+ */
+export const zodValidator = <
+  Target extends keyof ValidationTargets,
+  Schema extends z.AnyZodObject,
+>(
+  target: Target,
+  schema: Schema,
+) => {
+  return validator(target, (value): Schema["_output"] => {
+    const result = schema.safeParse(value);
+
+    if (!result.success) {
+      throw new HTTPException(400, {
+        message: "Invalid Request",
+        cause: result.error,
+      });
+    }
+
+    return result.data;
+  });
+};

--- a/templates/base/package.json
+++ b/templates/base/package.json
@@ -23,7 +23,6 @@
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "@cloudflare/workers-types": "^4.20250321.0",
-    "@fiberplane/hono-otel": "^0.6.2",
     "drizzle-kit": "^0.30.4",
     "drizzle-seed": "^0.3.1",
     "tsx": "^4.19.2",

--- a/templates/base/package.json
+++ b/templates/base/package.json
@@ -16,6 +16,7 @@
     "@neondatabase/serverless": "^0.10.4",
     "dotenv": "^16.4.7",
     "drizzle-orm": "^0.43.1",
+    "drizzle-zod": "^0.7.1",
     "hono": "^4.7.0",
     "zod": "^3.23.8"
   },

--- a/templates/base/src/dtos/index.ts
+++ b/templates/base/src/dtos/index.ts
@@ -3,14 +3,14 @@ import { z } from "zod";
 import * as schema from "../db/schema";
 
 export const ZUserInsert = createInsertSchema(schema.users, {
-  email: (schema) => schema.email()
+  email: (schema) => schema.email(),
 }).pick({
   name: true,
   email: true,
 });
 
 export const ZUserSelect = createSelectSchema(schema.users, {
-  id: (schema) => schema.uuid(), 
+  id: (schema) => schema.uuid(),
   email: (schema) => schema.email(),
 });
 

--- a/templates/base/src/dtos/index.ts
+++ b/templates/base/src/dtos/index.ts
@@ -1,0 +1,19 @@
+import { createInsertSchema, createSelectSchema } from "drizzle-zod";
+import { z } from "zod";
+import * as schema from "../db/schema";
+
+export const ZUserInsert = createInsertSchema(schema.users, {
+  email: (schema) => schema.email()
+}).pick({
+  name: true,
+  email: true,
+});
+
+export const ZUserSelect = createSelectSchema(schema.users, {
+  id: (schema) => schema.uuid(), 
+  email: (schema) => schema.email(),
+});
+
+export const ZUserByIDParams = z.object({
+  id: z.string().uuid(),
+});

--- a/templates/base/src/index.ts
+++ b/templates/base/src/index.ts
@@ -34,39 +34,31 @@ const api = new Hono()
 
     return c.json(users);
   })
-  .post(
-    "/users", 
-    zodValidator("json", ZUserInsert),
-    async (c) => {
-      const db = c.var.db;
-      const { name, email } = c.req.valid("json");
+  .post("/users", zodValidator("json", ZUserInsert), async (c) => {
+    const db = c.var.db;
+    const { name, email } = c.req.valid("json");
 
-      const [newUser] = await db
-        .insert(schema.users)
-        .values({
-          name: name,
-          email: email,
-        })
-        .returning();
+    const [newUser] = await db
+      .insert(schema.users)
+      .values({
+        name: name,
+        email: email,
+      })
+      .returning();
 
-      return c.json(newUser, 201);
-    }
-  )
-  .get(
-    "/users/:id",
-    zodValidator("param", ZUserByIDParams),
-    async (c) => {
-      const db = c.var.db;
-      const { id } = c.req.valid("param");
+    return c.json(newUser, 201);
+  })
+  .get("/users/:id", zodValidator("param", ZUserByIDParams), async (c) => {
+    const db = c.var.db;
+    const { id } = c.req.valid("param");
 
-      const [user] = await db
-        .select()
-        .from(schema.users)
-        .where(eq(schema.users.id, id));
+    const [user] = await db
+      .select()
+      .from(schema.users)
+      .where(eq(schema.users.id, id));
 
-      return c.json(user);
-    }
-  );
+    return c.json(user);
+  });
 
 const app = new Hono()
   .get("/", (c) => {

--- a/templates/base/src/index.ts
+++ b/templates/base/src/index.ts
@@ -6,6 +6,8 @@ import { Hono } from "hono";
 import { createMiddleware } from "hono/factory";
 import { HTTPException } from "hono/http-exception";
 import * as schema from "./db/schema";
+import { ZUserByIDParams, ZUserInsert } from "./dtos";
+import { zodValidator } from "./middleware/validator";
 
 const initDb = createMiddleware<{
   Bindings: {
@@ -32,31 +34,39 @@ const api = new Hono()
 
     return c.json(users);
   })
-  .post("/users", async (c) => {
-    const db = c.var.db;
-    const { name, email } = await c.req.json();
+  .post(
+    "/users", 
+    zodValidator("json", ZUserInsert),
+    async (c) => {
+      const db = c.var.db;
+      const { name, email } = c.req.valid("json");
 
-    const [newUser] = await db
-      .insert(schema.users)
-      .values({
-        name: name,
-        email: email,
-      })
-      .returning();
+      const [newUser] = await db
+        .insert(schema.users)
+        .values({
+          name: name,
+          email: email,
+        })
+        .returning();
 
-    return c.json(newUser, 201);
-  })
-  .get("/users/:id", async (c) => {
-    const db = c.var.db;
-    const id = c.req.param("id");
+      return c.json(newUser, 201);
+    }
+  )
+  .get(
+    "/users/:id",
+    zodValidator("param", ZUserByIDParams),
+    async (c) => {
+      const db = c.var.db;
+      const { id } = c.req.valid("param");
 
-    const [user] = await db
-      .select()
-      .from(schema.users)
-      .where(eq(schema.users.id, id));
+      const [user] = await db
+        .select()
+        .from(schema.users)
+        .where(eq(schema.users.id, id));
 
-    return c.json(user);
-  });
+      return c.json(user);
+    }
+  );
 
 const app = new Hono()
   .get("/", (c) => {

--- a/templates/base/src/middleware/validator.ts
+++ b/templates/base/src/middleware/validator.ts
@@ -1,6 +1,6 @@
 import type { ValidationTargets } from "hono";
-import { validator } from "hono/validator";
 import { HTTPException } from "hono/http-exception";
+import { validator } from "hono/validator";
 import type { z } from "zod";
 
 /**

--- a/templates/base/src/middleware/validator.ts
+++ b/templates/base/src/middleware/validator.ts
@@ -1,0 +1,31 @@
+import type { ValidationTargets } from "hono";
+import { validator } from "hono/validator";
+import { HTTPException } from "hono/http-exception";
+import type { z } from "zod";
+
+/**
+ * A wrapper around `hono/validator` configured for Zod schemas
+ * that standardizes error handling.
+ * @param target The relevant Hono validation target, e.g., "json" or "query"
+ * @param schema A Zod schema used to validate the selected target
+ */
+export const zodValidator = <
+  Target extends keyof ValidationTargets,
+  Schema extends z.AnyZodObject,
+>(
+  target: Target,
+  schema: Schema,
+) => {
+  return validator(target, (value): Schema["_output"] => {
+    const result = schema.safeParse(value);
+
+    if (!result.success) {
+      throw new HTTPException(400, {
+        message: "Invalid Request",
+        cause: result.error,
+      });
+    }
+
+    return result.data;
+  });
+};

--- a/templates/d1-openapi/package.json
+++ b/templates/d1-openapi/package.json
@@ -16,7 +16,6 @@
   },
   "dependencies": {
     "@fiberplane/hono": "0.5.2",
-    "@hono/zod-validator": "^0.4.3",
     "dotenv": "^16.4.5",
     "drizzle-orm": "^0.39.3",
     "drizzle-zod": "^0.7.1",

--- a/templates/d1-openapi/seed.ts
+++ b/templates/d1-openapi/seed.ts
@@ -33,6 +33,8 @@ async function seedDatabase() {
         users: {
           columns: {
             id: funcs.uuid(),
+            createdAt: funcs.timestamp(),
+            updatedAt: funcs.timestamp(),
           }
         }
       }));

--- a/templates/d1-openapi/src/dtos/index.ts
+++ b/templates/d1-openapi/src/dtos/index.ts
@@ -3,7 +3,14 @@ import { z } from "zod";
 import "zod-openapi/extend";
 import * as schema from "../db/schema";
 
-export const ZUserInsert = createInsertSchema(schema.users)
+export const ZUserInsert = createInsertSchema(schema.users, {
+  name: (schema) => schema.openapi({ 
+    example: "Goose McCloud",
+  }),
+  email: (schema) => schema.email().openapi({ 
+    example: "goose@honc.dev",
+  }),
+})
   .pick({
     name: true,
     email: true,
@@ -12,7 +19,23 @@ export const ZUserInsert = createInsertSchema(schema.users)
     ref: "UserInsert",
   });
 
-export const ZUserSelect = createSelectSchema(schema.users).openapi({
+export const ZUserSelect = createSelectSchema(schema.users, {
+  id: (schema) => schema.uuid().openapi({ 
+    example: "3e0bb3d0-2074-4a1e-6263-d13dd10cb0cf" 
+  }), 
+  name: (schema) => schema.openapi({ 
+    example: "Goose McCloud",
+  }),
+  email: (schema) => schema.email().openapi({ 
+    example: "goose@honc.dev",
+  }),
+  createdAt: (schema) => schema.openapi({ 
+    example: "2025-05-15 04:13:29",
+  }),
+  updatedAt: (schema) => schema.openapi({ 
+    example: "2025-05-15 04:13:29",
+  }),
+}).openapi({
   ref: "UserSelect",
 });
 

--- a/templates/d1-openapi/src/dtos/index.ts
+++ b/templates/d1-openapi/src/dtos/index.ts
@@ -4,12 +4,14 @@ import "zod-openapi/extend";
 import * as schema from "../db/schema";
 
 export const ZUserInsert = createInsertSchema(schema.users, {
-  name: (schema) => schema.openapi({ 
-    example: "Goose McCloud",
-  }),
-  email: (schema) => schema.email().openapi({ 
-    example: "goose@honc.dev",
-  }),
+  name: (schema) =>
+    schema.openapi({
+      example: "Goose McCloud",
+    }),
+  email: (schema) =>
+    schema.email().openapi({
+      example: "goose@honc.dev",
+    }),
 })
   .pick({
     name: true,
@@ -20,21 +22,26 @@ export const ZUserInsert = createInsertSchema(schema.users, {
   });
 
 export const ZUserSelect = createSelectSchema(schema.users, {
-  id: (schema) => schema.uuid().openapi({ 
-    example: "3e0bb3d0-2074-4a1e-6263-d13dd10cb0cf" 
-  }), 
-  name: (schema) => schema.openapi({ 
-    example: "Goose McCloud",
-  }),
-  email: (schema) => schema.email().openapi({ 
-    example: "goose@honc.dev",
-  }),
-  createdAt: (schema) => schema.openapi({ 
-    example: "2025-05-15 04:13:29",
-  }),
-  updatedAt: (schema) => schema.openapi({ 
-    example: "2025-05-15 04:13:29",
-  }),
+  id: (schema) =>
+    schema.uuid().openapi({
+      example: "3e0bb3d0-2074-4a1e-6263-d13dd10cb0cf",
+    }),
+  name: (schema) =>
+    schema.openapi({
+      example: "Goose McCloud",
+    }),
+  email: (schema) =>
+    schema.email().openapi({
+      example: "goose@honc.dev",
+    }),
+  createdAt: (schema) =>
+    schema.openapi({
+      example: "2025-05-15 04:13:29",
+    }),
+  updatedAt: (schema) =>
+    schema.openapi({
+      example: "2025-05-15 04:13:29",
+    }),
 }).openapi({
   ref: "UserSelect",
 });

--- a/templates/d1/package.json
+++ b/templates/d1/package.json
@@ -25,7 +25,6 @@
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "@cloudflare/workers-types": "^4.20250321.0",
-    "@fiberplane/hono-otel": "^0.6.2",
     "@libsql/client": "^0.14.0",
     "drizzle-kit": "^0.30.4",
     "drizzle-seed": "^0.3.1",

--- a/templates/d1/package.json
+++ b/templates/d1/package.json
@@ -18,6 +18,7 @@
     "@fiberplane/hono": "0.5.2",
     "dotenv": "^16.4.7",
     "drizzle-orm": "^0.43.1",
+    "drizzle-zod": "^0.7.1",
     "hono": "^4.7.0",
     "zod": "^3.23.8"
   },

--- a/templates/d1/seed.ts
+++ b/templates/d1/seed.ts
@@ -33,6 +33,8 @@ async function seedDatabase() {
         users: {
           columns: {
             id: funcs.uuid(),
+            createdAt: funcs.timestamp(),
+            updatedAt: funcs.timestamp(),
           }
         }
       }));

--- a/templates/d1/src/db/schema.ts
+++ b/templates/d1/src/db/schema.ts
@@ -20,7 +20,9 @@ export const users = sqliteTable(
   "users",
   {
     // .primaryKey() must be chained before $defaultFn
-    id: text().primaryKey().$defaultFn(() => crypto.randomUUID()),
+    id: text()
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
     name: text().notNull(),
     email: text().notNull(),
     createdAt: text().notNull().default(currentTimestamp()),

--- a/templates/d1/src/dtos/index.ts
+++ b/templates/d1/src/dtos/index.ts
@@ -3,14 +3,14 @@ import { z } from "zod";
 import * as schema from "../db/schema";
 
 export const ZUserInsert = createInsertSchema(schema.users, {
-  email: (schema) => schema.email()
+  email: (schema) => schema.email(),
 }).pick({
   name: true,
   email: true,
 });
 
 export const ZUserSelect = createSelectSchema(schema.users, {
-  id: (schema) => schema.uuid(), 
+  id: (schema) => schema.uuid(),
   email: (schema) => schema.email(),
 });
 

--- a/templates/d1/src/dtos/index.ts
+++ b/templates/d1/src/dtos/index.ts
@@ -1,0 +1,19 @@
+import { createInsertSchema, createSelectSchema } from "drizzle-zod";
+import { z } from "zod";
+import * as schema from "../db/schema";
+
+export const ZUserInsert = createInsertSchema(schema.users, {
+  email: (schema) => schema.email()
+}).pick({
+  name: true,
+  email: true,
+});
+
+export const ZUserSelect = createSelectSchema(schema.users, {
+  id: (schema) => schema.uuid(), 
+  email: (schema) => schema.email(),
+});
+
+export const ZUserByIDParams = z.object({
+  id: z.string().uuid(),
+});

--- a/templates/d1/src/index.ts
+++ b/templates/d1/src/index.ts
@@ -5,8 +5,8 @@ import { Hono } from "hono";
 import { createMiddleware } from "hono/factory";
 import { HTTPException } from "hono/http-exception";
 import * as schema from "./db/schema";
-import { zodValidator } from "./middleware/validator";
 import { ZUserByIDParams, ZUserInsert } from "./dtos";
+import { zodValidator } from "./middleware/validator";
 
 const initDb = createMiddleware<{
   Bindings: {
@@ -32,39 +32,31 @@ const api = new Hono()
 
     return c.json(users);
   })
-  .post(
-    "/users",
-    zodValidator("json", ZUserInsert),
-    async (c) => {
-      const db = c.var.db;
-      const { name, email } = c.req.valid("json");
+  .post("/users", zodValidator("json", ZUserInsert), async (c) => {
+    const db = c.var.db;
+    const { name, email } = c.req.valid("json");
 
-      const [newUser] = await db
-        .insert(schema.users)
-        .values({
-          name: name,
-          email: email,
-        })
-        .returning();
+    const [newUser] = await db
+      .insert(schema.users)
+      .values({
+        name: name,
+        email: email,
+      })
+      .returning();
 
-      return c.json(newUser, 201);
-    }
-  )
-  .get(
-    "/users/:id",
-    zodValidator("param", ZUserByIDParams),
-    async (c) => {
-      const db = c.var.db;
-      const { id } = c.req.valid("param");
+    return c.json(newUser, 201);
+  })
+  .get("/users/:id", zodValidator("param", ZUserByIDParams), async (c) => {
+    const db = c.var.db;
+    const { id } = c.req.valid("param");
 
-      const [user] = await db
-        .select()
-        .from(schema.users)
-        .where(eq(schema.users.id, id));
+    const [user] = await db
+      .select()
+      .from(schema.users)
+      .where(eq(schema.users.id, id));
 
-      return c.json(user);
-    }
-  );
+    return c.json(user);
+  });
 
 const app = new Hono()
   .get("/", (c) => {

--- a/templates/d1/src/index.ts
+++ b/templates/d1/src/index.ts
@@ -5,6 +5,8 @@ import { Hono } from "hono";
 import { createMiddleware } from "hono/factory";
 import { HTTPException } from "hono/http-exception";
 import * as schema from "./db/schema";
+import { zodValidator } from "./middleware/validator";
+import { ZUserByIDParams, ZUserInsert } from "./dtos";
 
 const initDb = createMiddleware<{
   Bindings: {
@@ -30,31 +32,39 @@ const api = new Hono()
 
     return c.json(users);
   })
-  .post("/users", async (c) => {
-    const db = c.var.db;
-    const { name, email } = await c.req.json();
+  .post(
+    "/users",
+    zodValidator("json", ZUserInsert),
+    async (c) => {
+      const db = c.var.db;
+      const { name, email } = c.req.valid("json");
 
-    const [newUser] = await db
-      .insert(schema.users)
-      .values({
-        name: name,
-        email: email,
-      })
-      .returning();
+      const [newUser] = await db
+        .insert(schema.users)
+        .values({
+          name: name,
+          email: email,
+        })
+        .returning();
 
-    return c.json(newUser, 201);
-  })
-  .get("/users/:id", async (c) => {
-    const db = c.var.db;
-    const id = c.req.param("id");
+      return c.json(newUser, 201);
+    }
+  )
+  .get(
+    "/users/:id",
+    zodValidator("param", ZUserByIDParams),
+    async (c) => {
+      const db = c.var.db;
+      const { id } = c.req.valid("param");
 
-    const [user] = await db
-      .select()
-      .from(schema.users)
-      .where(eq(schema.users.id, id));
+      const [user] = await db
+        .select()
+        .from(schema.users)
+        .where(eq(schema.users.id, id));
 
-    return c.json(user);
-  });
+      return c.json(user);
+    }
+  );
 
 const app = new Hono()
   .get("/", (c) => {

--- a/templates/d1/src/middleware/validator.ts
+++ b/templates/d1/src/middleware/validator.ts
@@ -1,6 +1,6 @@
 import type { ValidationTargets } from "hono";
-import { validator } from "hono/validator";
 import { HTTPException } from "hono/http-exception";
+import { validator } from "hono/validator";
 import type { z } from "zod";
 
 /**

--- a/templates/d1/src/middleware/validator.ts
+++ b/templates/d1/src/middleware/validator.ts
@@ -1,0 +1,31 @@
+import type { ValidationTargets } from "hono";
+import { validator } from "hono/validator";
+import { HTTPException } from "hono/http-exception";
+import type { z } from "zod";
+
+/**
+ * A wrapper around `hono/validator` configured for Zod schemas
+ * that standardizes error handling.
+ * @param target The relevant Hono validation target, e.g., "json" or "query"
+ * @param schema A Zod schema used to validate the selected target
+ */
+export const zodValidator = <
+  Target extends keyof ValidationTargets,
+  Schema extends z.AnyZodObject,
+>(
+  target: Target,
+  schema: Schema,
+) => {
+  return validator(target, (value): Schema["_output"] => {
+    const result = schema.safeParse(value);
+
+    if (!result.success) {
+      throw new HTTPException(400, {
+        message: "Invalid Request",
+        cause: result.error,
+      });
+    }
+
+    return result.data;
+  });
+};


### PR DESCRIPTION
## What changed
### OpenAPI templates
- narrow zod schemas (e.g., `uuid` or `email`) + add openapi examples
### Non-OpenAPI templates
- add custom zod validator
- add `drizzle-zod` generated dtos
- validate payloads + params
### Also
- add `timestamp` refinements to seeding in both D1 templates
### Callouts
- adding @types/node to the `base-supa-openapi` template was necessary to get types working
  - not sure what the issue is yet. doesn't seem to affect `base-supa` template though
- pg + sqlite have different datetime formats, which could affect standardized testing
  - both seem to work fine with `new Date()` though 
