### PR TITLE
Add target dir cli arg

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "pnpm clean && tsup",
     "dev": "tsup --watch && node dist/index.js",
+    "dev:target": "tsup --watch --onSuccess 'node dist/index.js ./test-apps/test-path'",
     "dev:hatch": "tsup --watch --onSuccess 'node dist/index.js --hatch'",
     "format": "biome format . --write",
     "typecheck": "tsc --noEmit",

--- a/cli/src/context.ts
+++ b/cli/src/context.ts
@@ -1,6 +1,6 @@
 import { existsSync, readdirSync } from "node:fs";
-import { confirm, log } from "@clack/prompts";
 import type { ScaffoldedFiles } from "@/integrations/code-gen";
+import { confirm, log } from "@clack/prompts";
 import type { Flags, Template } from "./types";
 import { getPackageManager } from "./utils";
 
@@ -134,18 +134,18 @@ function parseHatchFlag(args: string[]): string | boolean {
 
 /**
  * Parses the target directory from command line arguments.
- * 
+ *
  * @param args - An array of command line arguments.
  * @returns
  *   - `undefined` if the last argument isn't a directory path.
  *   - The relative target path as a `string`.
- * 
+ *
  * @description Checks if the last argument is a valid directory:
- * 
+ *
  * 1. If no arguments, or last argument is not a target directory, returns `undefined`.
  * 2. If last argument is invalid target (non-relative path), logs error and exits.
  * 3. If valid target exists but has contents, requests confirmation before continuing.
- * 
+ *
  * @example
  * parseTargetDirectory([]) // Returns `undefined`
  * parseTargetDirectory(["--any-flag"]) // Returns `undefined`

--- a/cli/src/context.ts
+++ b/cli/src/context.ts
@@ -1,3 +1,5 @@
+import { existsSync, readdirSync } from "node:fs";
+import { confirm, log } from "@clack/prompts";
 import type { ScaffoldedFiles } from "@/integrations/code-gen";
 import type { Flags, Template } from "./types";
 import { getPackageManager } from "./utils";
@@ -61,12 +63,15 @@ export interface Context {
   hatchValue: string | boolean;
 }
 
-export function initContext(): Context {
+export async function initContext(): Promise<Context> {
+  const target = await parseTargetDirectory(process.argv);
+
   const hatchValue = parseHatchFlag(process.argv);
   const flags: Flags = hatchValue ? ["hatch"] : [];
 
   return {
     cwd: process.cwd(),
+    path: target,
     packageManager: getPackageManager() ?? "npm",
     flags,
 
@@ -125,4 +130,54 @@ function parseHatchFlag(args: string[]): string | boolean {
   }
   // Otherwise, just set it to true
   return true;
+}
+
+/**
+ * Parses the target directory from command line arguments.
+ * 
+ * @param args - An array of command line arguments.
+ * @returns
+ *   - `undefined` if the last argument isn't a directory path.
+ *   - The relative target path as a `string`.
+ * 
+ * @description Checks if the last argument is a valid directory:
+ * 
+ * 1. If no arguments, or last argument is not a target directory, returns `undefined`.
+ * 2. If last argument is invalid target (non-relative path), logs error and exits.
+ * 3. If valid target exists but has contents, requests confirmation before continuing.
+ * 
+ * @example
+ * parseTargetDirectory([]) // Returns `undefined`
+ * parseTargetDirectory(["--any-flag"]) // Returns `undefined`
+ * parseTargetDirectory(["/invalid-target"]) // Logs error and exits
+ * parseTargetDirectory(["./valid-target", "--any-flag"]) // Returns `undefined`
+ * parseTargetDirectory(["./valid-target"]) // Returns "./valid-target"
+ * parseTargetDirectory(["--any-flag", "./valid-target"]) // Returns "./valid-target"
+ */
+async function parseTargetDirectory(args: string[]) {
+  const target = args.at(-1);
+
+  // `.js` check ignores `process.execPath`
+  // https://nodejs.org/docs/latest/api/process.html#processargv
+  if (!target || target.startsWith("-") || target.endsWith(".js")) {
+    return undefined;
+  }
+
+  if (target[0] !== ".") {
+    log.error("Please enter a relative path.");
+    process.exit(1);
+  }
+
+  if (existsSync(target) && readdirSync(target).length > 0) {
+    const confirmation = await confirm({
+      message: "Target directory isn't empty. Continue?",
+      initialValue: false,
+    });
+
+    if (!confirmation) {
+      process.exit(1);
+    }
+  }
+
+  return target;
 }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -30,7 +30,7 @@ async function main() {
 
   intro("🪿 create-honc-app");
 
-  const context = initContext();
+  const context = await initContext();
 
   // If the hatch flag is present, we should use its value
   const shouldHatch = typeof context.hatchValue === "string";
@@ -40,10 +40,12 @@ async function main() {
 
   // If the hatch flag is present but without a value, we should prompt for a description
   const shouldPromptDescription = context.hatchValue === true;
+  // If target path not included in CLI args, we should prompt for a path
+  const shouldPromptPath = !context.path;
 
   const prompts = [
     shouldPromptDescription ? promptDescription : undefined,
-    promptPath,
+    shouldPromptPath ? promptPath : undefined,
     promptTemplate,
     promptOpenAPI,
     promptDatabase,


### PR DESCRIPTION
## What changed
- add logic to parse target directory path from CLI args, if present
  - closes https://github.com/fiberplane/create-honc-app/issues/31 
- skip path prompt if target passed as CLI arg
- add script to run `dev` with path arg

## Testing
- run `pnpm run dev:target` to test valid path argument
- modify script (e.g., remove `.` from path) + run to test with invalid path argument
- run `pnpm run dev` to test standard flow

## Note
- if target dir is populated and user chooses to continue, overlapping files/dirs will be overwritten, but unrelated files are not deleted